### PR TITLE
Add back basic chat implementation

### DIFF
--- a/server/src/broadcasters/chat.rs
+++ b/server/src/broadcasters/chat.rs
@@ -1,7 +1,7 @@
 //! Broadcasting of chat messages
 
+use crate::player::chat::{ChatBroadcastEvent, ChatPosition};
 use crate::state::State;
-use crate::player::chat::{ ChatBroadcastEvent, ChatPosition };
 use feather_core::network::packet::implementation::ChatMessageClientbound;
 
 /// System that broadcasts chat messages to all players
@@ -12,8 +12,8 @@ fn broadcast_chat(event: &ChatBroadcastEvent, state: &State) {
         position: match event.position {
             ChatPosition::Chat => 0,
             ChatPosition::SystemMessage => 1,
-            ChatPosition::GameInfo => 2
-        }
+            ChatPosition::GameInfo => 2,
+        },
     };
     state.broadcast_global(packet, None);
 }

--- a/server/src/broadcasters/chat.rs
+++ b/server/src/broadcasters/chat.rs
@@ -1,0 +1,19 @@
+//! Broadcasting of chat messages
+
+use crate::state::State;
+use crate::player::chat::{ ChatBroadcastEvent, ChatPosition };
+use feather_core::network::packet::implementation::ChatMessageClientbound;
+
+/// System that broadcasts chat messages to all players
+#[event_handler]
+fn broadcast_chat(event: &ChatBroadcastEvent, state: &State) {
+    let packet = ChatMessageClientbound {
+        json_data: event.json_data.clone(),
+        position: match event.position {
+            ChatPosition::Chat => 0,
+            ChatPosition::SystemMessage => 1,
+            ChatPosition::GameInfo => 2
+        }
+    };
+    state.broadcast_global(packet, None);
+}

--- a/server/src/broadcasters/mod.rs
+++ b/server/src/broadcasters/mod.rs
@@ -14,3 +14,4 @@ mod inventory;
 pub mod keepalive;
 mod metadata;
 pub mod movement;
+mod chat;

--- a/server/src/broadcasters/mod.rs
+++ b/server/src/broadcasters/mod.rs
@@ -8,10 +8,10 @@
 
 mod animation;
 mod block;
+mod chat;
 pub mod entity_creation;
 pub mod entity_deletion;
 mod inventory;
 pub mod keepalive;
 mod metadata;
 pub mod movement;
-mod chat;

--- a/server/src/packet_handlers/chat.rs
+++ b/server/src/packet_handlers/chat.rs
@@ -1,0 +1,16 @@
+use crate::network::PacketQueue;
+use crate::player::chat::PlayerChatEvent;
+use feather_core::network::packet::implementation::ChatMessageServerbound;
+use tonks::Trigger;
+
+/// Handles animation packets.
+#[system]
+fn handle_chat(queue: &PacketQueue, trigger: &mut Trigger<PlayerChatEvent>) {
+    queue
+        .received::<ChatMessageServerbound>()
+        .for_each(|(player, packet)| {
+            let message = packet.message;
+
+            trigger.trigger(PlayerChatEvent { player, message });
+        });
+}

--- a/server/src/packet_handlers/mod.rs
+++ b/server/src/packet_handlers/mod.rs
@@ -1,8 +1,8 @@
 //! Systems which handle packets through `crate::network::PacketQueue`.
 
 mod animation;
+mod chat;
 mod digging;
 mod inventory;
 mod movement;
 mod placement;
-mod chat;

--- a/server/src/packet_handlers/mod.rs
+++ b/server/src/packet_handlers/mod.rs
@@ -5,3 +5,4 @@ mod digging;
 mod inventory;
 mod movement;
 mod placement;
+mod chat;

--- a/server/src/player/chat.rs
+++ b/server/src/player/chat.rs
@@ -1,5 +1,5 @@
-use legion::entity::Entity;
 use crate::entity::Name;
+use legion::entity::Entity;
 use legion::query::Read;
 use tonks::{PreparedWorld, Query, Trigger};
 
@@ -10,7 +10,7 @@ pub struct PlayerChatEvent {
     pub player: Entity,
 
     /// The raw message that was sent
-    pub message: String
+    pub message: String,
 }
 
 /// Event that will result in a chat message being broadcasted
@@ -19,8 +19,8 @@ pub struct ChatBroadcastEvent {
     /// A JSON string representing the Chat component to sent
     pub json_data: String,
 
-    /// The position 
-    pub position: ChatPosition
+    /// The position
+    pub position: ChatPosition,
 }
 
 /// Different positions a chat message can be displayed
@@ -32,15 +32,18 @@ pub enum ChatPosition {
     SystemMessage,
 
     /// A text displayed above the hotbar
-    GameInfo
+    GameInfo,
 }
 
 /// System that broadcasts chat messages to all players
 #[event_handler]
-fn broadcast_chat(event: &PlayerChatEvent, world: &mut PreparedWorld, _query: &mut Query<Read<Name>>, trigger: &mut Trigger<ChatBroadcastEvent>) {
-    let player_name = &world.get_component::<Name>(event.player)
-        .unwrap()
-        .0;
+fn broadcast_chat(
+    event: &PlayerChatEvent,
+    world: &mut PreparedWorld,
+    _query: &mut Query<Read<Name>>,
+    trigger: &mut Trigger<ChatBroadcastEvent>,
+) {
+    let player_name = &world.get_component::<Name>(event.player).unwrap().0;
 
     let json_data = json!({
         "translate": "chat.type.text",
@@ -48,11 +51,12 @@ fn broadcast_chat(event: &PlayerChatEvent, world: &mut PreparedWorld, _query: &m
             {"text": player_name},
             {"text": event.message}
         ]
-    }).to_string();
-    
+    })
+    .to_string();
+
     trigger.trigger(ChatBroadcastEvent {
         json_data,
-        position: ChatPosition::Chat
+        position: ChatPosition::Chat,
     });
 
     info!("<{}> {}", player_name, event.message);

--- a/server/src/player/chat.rs
+++ b/server/src/player/chat.rs
@@ -1,0 +1,59 @@
+use legion::entity::Entity;
+use crate::entity::Name;
+use legion::query::Read;
+use tonks::{PreparedWorld, Query, Trigger};
+
+/// Event triggered when a player sends a chat message
+#[derive(Debug, Clone)]
+pub struct PlayerChatEvent {
+    /// The player that sent the chat message
+    pub player: Entity,
+
+    /// The raw message that was sent
+    pub message: String
+}
+
+/// Event that will result in a chat message being broadcasted
+pub struct ChatBroadcastEvent {
+    // TODO: Use composable chat component here
+    /// A JSON string representing the Chat component to sent
+    pub json_data: String,
+
+    /// The position 
+    pub position: ChatPosition
+}
+
+/// Different positions a chat message can be displayed
+pub enum ChatPosition {
+    /// Simple message displayed in the chat box
+    Chat,
+
+    /// System message displayed in the chat box
+    SystemMessage,
+
+    /// A text displayed above the hotbar
+    GameInfo
+}
+
+/// System that broadcasts chat messages to all players
+#[event_handler]
+fn broadcast_chat(event: &PlayerChatEvent, world: &mut PreparedWorld, _query: &mut Query<Read<Name>>, trigger: &mut Trigger<ChatBroadcastEvent>) {
+    let player_name = &world.get_component::<Name>(event.player)
+        .unwrap()
+        .0;
+
+    let json_data = json!({
+        "translate": "chat.type.text",
+        "with": [
+            {"text": player_name},
+            {"text": event.message}
+        ]
+    }).to_string();
+    
+    trigger.trigger(ChatBroadcastEvent {
+        json_data,
+        position: ChatPosition::Chat
+    });
+
+    info!("<{}> {}", player_name, event.message);
+}

--- a/server/src/player/mod.rs
+++ b/server/src/player/mod.rs
@@ -17,6 +17,8 @@ use mojang_api::ProfileProperty;
 use tonks::{EntityAccessor, PreparedWorld};
 use uuid::Uuid;
 
+pub mod chat;
+
 pub const PLAYER_EYE_HEIGHT: f64 = 1.62;
 
 /// Profile properties of a player.


### PR DESCRIPTION
I noticed the chat implementation was left out from the Legion refactor. I saw an opportunity to get my feet wet with the feather codebase and Legion so I added it back in again.

Changes were based on #73 and #75 

There are no tests, I could not find any examples of other broadcasters with tests.
I can add them if you like, but I would need a hint on where to get started.