### PR TITLE
Fixed codegen target folder not being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /blocks/target
 /server/target
 /core/target
+/codegen/target
 **/*.rs.bk
 **/.idea
 feather.toml


### PR DESCRIPTION
The codegen target folder is not present in the gitignore file.

Some of the other projects are also not present in the gitignore, but I'm not getting a target folder there when running `cargo build`.