### PR TITLE
Heightmaps

### DIFF
--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -73,6 +73,12 @@ pub trait BlockExt {
     /// light will be stopped by this block.
     fn is_opaque(&self) -> bool;
 
+    fn is_air(&self) -> bool;
+
+    fn is_fluid(&self) -> bool;
+
+    fn is_leaves(&self) -> bool;
+
     /// Returns the light level emitted by this block.
     fn light_emission(&self) -> u8;
 }
@@ -211,6 +217,32 @@ impl BlockExt for Block {
         match self {
             Block::Air | Block::Glass | Block::GlassPane(_) | Block::IronBars(_) => false,
             _ => true,
+        }
+    }
+
+    fn is_air(&self) -> bool {
+        match self {
+            Block::Air | Block::CaveAir | Block::VoidAir => true,
+            _ => false
+        }
+    }
+
+    fn is_fluid(&self) -> bool {
+        match self {
+            Block::Water(_) | Block::Lava(_) => true,
+            _ => false,
+        }
+    }
+
+    fn is_leaves(&self) -> bool {
+        match self {
+            Block::AcaciaLeaves(_)
+            | Block::BirchLeaves(_)
+            | Block::DarkOakLeaves(_)
+            | Block::JungleLeaves(_)
+            | Block::OakLeaves(_)
+            | Block::SpruceLeaves(_) => true,
+            _ => false,
         }
     }
 

--- a/blocks/src/lib.rs
+++ b/blocks/src/lib.rs
@@ -223,7 +223,7 @@ impl BlockExt for Block {
     fn is_air(&self) -> bool {
         match self {
             Block::Air | Block::CaveAir | Block::VoidAir => true,
-            _ => false
+            _ => false,
         }
     }
 

--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -1,7 +1,7 @@
 use crate::Biome;
 use crate::{Block, BlockExt, ChunkPosition};
-use multimap::MultiMap;
 use bitflags::bitflags;
+use multimap::MultiMap;
 
 /// The number of bits used for each block
 /// in the global palette.
@@ -75,7 +75,6 @@ pub struct HeightMap {
 }
 
 impl HeightMap {
-
     /// The highest block that is solid or contains a fluid.
     pub fn motion_blocking(&self) -> u8 {
         self.motion_blocking
@@ -273,7 +272,7 @@ impl Chunk {
 
     /// Recalculate the heightmap for the chunk
     pub fn recalculate_heightmap(&mut self) {
-        // This function can be optimized, instead of 
+        // This function can be optimized, instead of
         // fetching heightmap every time, and sections
         for x in 0..CHUNK_WIDTH {
             for z in 0..CHUNK_WIDTH {

--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -76,7 +76,7 @@ pub struct HeightMap {
 
 impl HeightMap {
     /// The highest block that is solid or contains a fluid.
-    pub fn motion_blocking(&self) -> u8 {
+    pub fn motion_blocking(self) -> u8 {
         self.motion_blocking
     }
 

--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -76,11 +76,11 @@ pub struct HeightMap {
 
 impl HeightMap {
     /// The highest block that is solid or contains a fluid.
-    pub fn motion_blocking(self) -> u8 {
+    pub fn motion_blocking(&self) -> u8 {
         self.motion_blocking
     }
 
-    pub fn set_motion_blocking(mut self, motion_blocking: u8) {
+    pub fn set_motion_blocking(&mut self, motion_blocking: u8) {
         self.motion_blocking = motion_blocking;
     }
 
@@ -89,7 +89,7 @@ impl HeightMap {
         self.motion_blocking_no_leaves
     }
 
-    pub fn set_motion_blocking_no_leaves(mut self, motion_blocking_no_leaves: u8) {
+    pub fn set_motion_blocking_no_leaves(&mut self, motion_blocking_no_leaves: u8) {
         self.motion_blocking_no_leaves = motion_blocking_no_leaves;
     }
 
@@ -98,7 +98,7 @@ impl HeightMap {
         self.ocean_floor
     }
 
-    pub fn set_ocean_floor(mut self, ocean_floor: u8) {
+    pub fn set_ocean_floor(&mut self, ocean_floor: u8) {
         self.ocean_floor = ocean_floor;
     }
 
@@ -112,7 +112,7 @@ impl HeightMap {
         self.world_surface
     }
 
-    pub fn set_world_surface(mut self, world_surface: u8) {
+    pub fn set_world_surface(&mut self, world_surface: u8) {
         self.world_surface = world_surface;
     }
 

--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -66,59 +66,59 @@ pub struct Chunk {
 
 #[derive(Clone, Copy, Default)]
 pub struct HeightMap {
-    motion_blocking: usize,
-    motion_blocking_no_leaves: usize,
-    ocean_floor: usize,
-    ocean_floor_wg: usize,
-    world_surface: usize,
-    world_surface_wg: usize,
+    motion_blocking: u8,
+    motion_blocking_no_leaves: u8,
+    ocean_floor: u8,
+    ocean_floor_wg: u8,
+    world_surface: u8,
+    world_surface_wg: u8,
 }
 
 impl HeightMap {
 
     /// The highest block that is solid or contains a fluid.
-    pub fn motion_blocking(&self) -> usize {
+    pub fn motion_blocking(&self) -> u8 {
         self.motion_blocking
     }
 
-    pub fn set_motion_blocking(&mut self, motion_blocking: usize) {
+    pub fn set_motion_blocking(&mut self, motion_blocking: u8) {
         self.motion_blocking = motion_blocking;
     }
 
     /// The highest block that is solid or contains a fluid and is not leaves.
-    pub fn motion_blocking_no_leaves(&self) -> usize {
+    pub fn motion_blocking_no_leaves(&self) -> u8 {
         self.motion_blocking_no_leaves
     }
 
-    pub fn set_motion_blocking_no_leaves(&mut self, motion_blocking_no_leaves: usize) {
+    pub fn set_motion_blocking_no_leaves(&mut self, motion_blocking_no_leaves: u8) {
         self.motion_blocking_no_leaves = motion_blocking_no_leaves;
     }
 
     /// The highest block that is solid.
-    pub fn ocean_floor(&self) -> usize {
+    pub fn ocean_floor(&self) -> u8 {
         self.ocean_floor
     }
 
-    pub fn set_ocean_floor(&mut self, ocean_floor: usize) {
+    pub fn set_ocean_floor(&mut self, ocean_floor: u8) {
         self.ocean_floor = ocean_floor;
     }
 
     /// The highest block that is solid for world generation.
-    pub fn ocean_floor_wg(&self) -> usize {
+    pub fn ocean_floor_wg(&self) -> u8 {
         self.ocean_floor_wg
     }
 
     /// The highest block that is not air.
-    pub fn world_surface(&self) -> usize {
+    pub fn world_surface(&self) -> u8 {
         self.world_surface
     }
 
-    pub fn set_world_surface(&mut self, world_surface: usize) {
+    pub fn set_world_surface(&mut self, world_surface: u8) {
         self.world_surface = world_surface;
     }
 
     /// The highest block is not air for world generation.
-    pub fn world_surface_wg(&self) -> usize {
+    pub fn world_surface_wg(&self) -> u8 {
         self.world_surface_wg
     }
 }
@@ -246,26 +246,26 @@ impl Chunk {
     fn update_heightmap(&mut self, x: usize, y: usize, z: usize, block: Block) -> HeightMapMask {
         let heightmap = self.heightmap_mut(x, z);
         let mut mask: HeightMapMask = HeightMapMask::empty();
-        if (block.is_solid() || block.is_fluid()) && heightmap.motion_blocking() < y {
-            heightmap.set_motion_blocking(y);
+        if (block.is_solid() || block.is_fluid()) && heightmap.motion_blocking() < y as u8 {
+            heightmap.set_motion_blocking(y as u8);
             mask |= HeightMapMask::MOTION_BLOCKING;
         }
 
         if (block.is_solid() || block.is_fluid())
             && !block.is_leaves()
-            && heightmap.motion_blocking_no_leaves() < y
+            && heightmap.motion_blocking_no_leaves() < y as u8
         {
-            heightmap.set_motion_blocking_no_leaves(y);
+            heightmap.set_motion_blocking_no_leaves(y as u8);
             mask |= HeightMapMask::MOTION_BLOCKING_NO_LEAVES;
         }
 
-        if block.is_solid() && heightmap.ocean_floor() < y {
-            heightmap.set_ocean_floor(y);
+        if block.is_solid() && heightmap.ocean_floor() < y as u8 {
+            heightmap.set_ocean_floor(y as u8);
             mask |= HeightMapMask::OCEAN_FLOOR;
         }
 
-        if !block.is_air() && heightmap.world_surface() < y {
-            heightmap.set_world_surface(y);
+        if !block.is_air() && heightmap.world_surface() < y as u8 {
+            heightmap.set_world_surface(y as u8);
             mask |= HeightMapMask::WORLD_SURFACE;
         }
         mask

--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -76,60 +76,60 @@ pub struct HeightMap {
 
 impl HeightMap {
     /// The highest block that is solid or contains a fluid.
-    pub fn motion_blocking(&self) -> u8 {
+    pub fn motion_blocking(self) -> u8 {
         self.motion_blocking
     }
 
-    pub fn set_motion_blocking(&mut self, motion_blocking: u8) {
+    pub fn set_motion_blocking(mut self, motion_blocking: u8) {
         self.motion_blocking = motion_blocking;
     }
 
     /// The highest block that is solid or contains a fluid and is not leaves.
-    pub fn motion_blocking_no_leaves(&self) -> u8 {
+    pub fn motion_blocking_no_leaves(self) -> u8 {
         self.motion_blocking_no_leaves
     }
 
-    pub fn set_motion_blocking_no_leaves(&mut self, motion_blocking_no_leaves: u8) {
+    pub fn set_motion_blocking_no_leaves(mut self, motion_blocking_no_leaves: u8) {
         self.motion_blocking_no_leaves = motion_blocking_no_leaves;
     }
 
     /// The highest block that is solid.
-    pub fn ocean_floor(&self) -> u8 {
+    pub fn ocean_floor(self) -> u8 {
         self.ocean_floor
     }
 
-    pub fn set_ocean_floor(&mut self, ocean_floor: u8) {
+    pub fn set_ocean_floor(mut self, ocean_floor: u8) {
         self.ocean_floor = ocean_floor;
     }
 
     /// The highest block that is solid for world generation.
-    pub fn ocean_floor_wg(&self) -> u8 {
+    pub fn ocean_floor_wg(self) -> u8 {
         self.ocean_floor_wg
     }
 
     /// The highest block that is not air.
-    pub fn world_surface(&self) -> u8 {
+    pub fn world_surface(self) -> u8 {
         self.world_surface
     }
 
-    pub fn set_world_surface(&mut self, world_surface: u8) {
+    pub fn set_world_surface(mut self, world_surface: u8) {
         self.world_surface = world_surface;
     }
 
     /// The highest block is not air for world generation.
-    pub fn world_surface_wg(&self) -> u8 {
+    pub fn world_surface_wg(self) -> u8 {
         self.world_surface_wg
     }
 }
 
 bitflags! {
     struct HeightMapMask: u8 {
-        const MOTION_BLOCKING = 0b00000001;
-        const MOTION_BLOCKING_NO_LEAVES = 0b00000010;
-        const OCEAN_FLOOR = 0b00000100;
-        const OCEAN_FLOOR_WG = 0b00001000;
-        const WORLD_SURFACE = 0b00010000;
-        const WORLD_SURFACE_WG = 0b00100000;
+        const MOTION_BLOCKING = 0b0000_0001;
+        const MOTION_BLOCKING_NO_LEAVES = 0b0000_0010;
+        const OCEAN_FLOOR = 0b0000_0100;
+        const OCEAN_FLOOR_WG = 0b0000_1000;
+        const WORLD_SURFACE = 0b0001_0000;
+        const WORLD_SURFACE_WG = 0b0010_0000;
     }
 }
 

--- a/core/src/save/region/blob.rs
+++ b/core/src/save/region/blob.rs
@@ -24,26 +24,7 @@ fn level_to_value(level: ChunkLevel) -> Value {
     map.insert(String::from("InhabitedTime"), Value::Long(0)); // TODO
     map.insert(String::from("Biomes"), Value::IntArray(level.biomes));
 
-    let mut hmaps = HashMap::new();
-    hmaps.insert(
-        String::from("MOTION_BLOCKING"),
-        Value::LongArray(vec![0; 32]),
-    ); // TODO
-    hmaps.insert(
-        String::from("MOTION_BLOCKING_NO_LEAVES"),
-        Value::LongArray(vec![0; 32]),
-    ); // TODO
-    hmaps.insert(String::from("OCEAN_FLOOR"), Value::LongArray(vec![0; 32])); // TODO
-    hmaps.insert(
-        String::from("OCEAN_FLOOR_WG"),
-        Value::LongArray(vec![0; 32]),
-    ); // TODO
-    hmaps.insert(String::from("WORLD_SURFACE"), Value::LongArray(vec![0; 32])); // TODO
-    hmaps.insert(
-        String::from("WORLD_SURFACE_WG"),
-        Value::LongArray(vec![0; 32]),
-    ); // TODO
-    map.insert(String::from("Heightmaps"), Value::Compound(hmaps));
+    map.insert(String::from("Heightmaps"), Value::LongArray(level.heightmaps));
 
     let sections = level.sections.into_iter().map(section_to_value).collect();
     map.insert(String::from("Sections"), Value::List(sections));
@@ -158,6 +139,7 @@ mod tests {
                 }],
                 biomes: vec![10],
                 entities: vec![],
+                heightmaps: vec![],
             },
         };
 

--- a/core/src/save/region/blob.rs
+++ b/core/src/save/region/blob.rs
@@ -24,7 +24,10 @@ fn level_to_value(level: ChunkLevel) -> Value {
     map.insert(String::from("InhabitedTime"), Value::Long(0)); // TODO
     map.insert(String::from("Biomes"), Value::IntArray(level.biomes));
 
-    map.insert(String::from("Heightmaps"), Value::LongArray(level.heightmaps));
+    map.insert(
+        String::from("Heightmaps"),
+        Value::LongArray(level.heightmaps),
+    );
 
     let sections = level.sections.into_iter().map(section_to_value).collect();
     map.insert(String::from("Sections"), Value::List(sections));

--- a/core/src/save/region/mod.rs
+++ b/core/src/save/region/mod.rs
@@ -30,6 +30,9 @@ const DATA_VERSION: i32 = 1631;
 /// Length, in bytes, of a sector.
 const SECTOR_BYTES: usize = 4096;
 
+/// The offset for each heightmap value
+const HEIGHTMAP_OFFSET: usize = 9;
+
 /// Represents the data for a chunk after the "Chunk [x, y]" tag.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChunkRoot {
@@ -348,14 +351,19 @@ fn read_section_into_chunk(section: &LevelSection, chunk: &mut Chunk) -> Result<
 }
 
 fn chunk_to_chunk_root(chunk: &Chunk, entities: Vec<EntityData>) -> ChunkRoot {
-    let heightmaps: Vec<i64> = chunk.heightmaps().iter().map(|map| {
-        (map.motion_blocking() as i64) << (9 * 0)
-        + (map.motion_blocking_no_leaves() as i64) << (9 * 1)
-        + (map.ocean_floor() as i64) << (9 * 2)
-        + (map.ocean_floor_wg() as i64) << (9 * 3)
-        + (map.world_surface() as i64) << (9 * 4)
-        + (map.world_surface_wg() as i64) << (9 * 5)
-    }).collect();
+    let heightmaps: Vec<i64> = chunk
+        .heightmaps()
+        .iter()
+        .map(|map| {
+            (map.motion_blocking() as i64)
+                << (HEIGHTMAP_OFFSET * 0) + (map.motion_blocking_no_leaves() as i64)
+                << (HEIGHTMAP_OFFSET * 1) + (map.ocean_floor() as i64)
+                << (HEIGHTMAP_OFFSET * 2) + (map.ocean_floor_wg() as i64)
+                << (HEIGHTMAP_OFFSET * 3) + (map.world_surface() as i64)
+                << (HEIGHTMAP_OFFSET * 4) + (map.world_surface_wg() as i64)
+                << (HEIGHTMAP_OFFSET * 5)
+        })
+        .collect();
     ChunkRoot {
         level: ChunkLevel {
             x_pos: chunk.position().x,

--- a/core/src/save/region/mod.rs
+++ b/core/src/save/region/mod.rs
@@ -31,7 +31,7 @@ const DATA_VERSION: i32 = 1631;
 const SECTOR_BYTES: usize = 4096;
 
 /// The offset for each heightmap value
-const HEIGHTMAP_OFFSET: usize = 9;
+const HEIGHTMAP_OFFSET: i64 = 9;
 
 /// Represents the data for a chunk after the "Chunk [x, y]" tag.
 #[derive(Serialize, Deserialize, Debug)]
@@ -351,21 +351,6 @@ fn read_section_into_chunk(section: &LevelSection, chunk: &mut Chunk) -> Result<
 }
 
 fn chunk_to_chunk_root(chunk: &Chunk, entities: Vec<EntityData>) -> ChunkRoot {
-<<<<<<< HEAD
-    let heightmaps: Vec<i64> = chunk
-        .heightmaps()
-        .iter()
-        .map(|map| {
-            (map.motion_blocking() as i64)
-                << (HEIGHTMAP_OFFSET * 0) + (map.motion_blocking_no_leaves() as i64)
-                << (HEIGHTMAP_OFFSET * 1) + (map.ocean_floor() as i64)
-                << (HEIGHTMAP_OFFSET * 2) + (map.ocean_floor_wg() as i64)
-                << (HEIGHTMAP_OFFSET * 3) + (map.world_surface() as i64)
-                << (HEIGHTMAP_OFFSET * 4) + (map.world_surface_wg() as i64)
-                << (HEIGHTMAP_OFFSET * 5)
-        })
-        .collect();
-=======
     let heightmaps: Vec<i64> = chunk.heightmaps().iter().map(|map| {
         (map.motion_blocking() as i64) << (HEIGHTMAP_OFFSET * 0)
         + (map.motion_blocking_no_leaves() as i64) << (HEIGHTMAP_OFFSET * 1)
@@ -374,7 +359,6 @@ fn chunk_to_chunk_root(chunk: &Chunk, entities: Vec<EntityData>) -> ChunkRoot {
         + (map.world_surface() as i64) << (HEIGHTMAP_OFFSET * 4)
         + (map.world_surface_wg() as i64) << (HEIGHTMAP_OFFSET * 5)
     }).collect();
->>>>>>> f9d226bc7e727b4ff19f1c36ee34f7228464c81f
     ChunkRoot {
         level: ChunkLevel {
             x_pos: chunk.position().x,

--- a/core/src/save/region/mod.rs
+++ b/core/src/save/region/mod.rs
@@ -351,14 +351,18 @@ fn read_section_into_chunk(section: &LevelSection, chunk: &mut Chunk) -> Result<
 }
 
 fn chunk_to_chunk_root(chunk: &Chunk, entities: Vec<EntityData>) -> ChunkRoot {
-    let heightmaps: Vec<i64> = chunk.heightmaps().iter().map(|map| {
-        (map.motion_blocking() as i64) << (HEIGHTMAP_OFFSET * 0)
-        + (map.motion_blocking_no_leaves() as i64) << (HEIGHTMAP_OFFSET * 1)
-        + (map.ocean_floor() as i64) << (HEIGHTMAP_OFFSET * 2)
-        + (map.ocean_floor_wg() as i64) << (HEIGHTMAP_OFFSET * 3)
-        + (map.world_surface() as i64) << (HEIGHTMAP_OFFSET * 4)
-        + (map.world_surface_wg() as i64) << (HEIGHTMAP_OFFSET * 5)
-    }).collect();
+    let heightmaps: Vec<i64> = chunk
+        .heightmaps()
+        .iter()
+        .map(|map| {
+            (map.motion_blocking() as i64)
+                + ((map.motion_blocking_no_leaves() as i64) << HEIGHTMAP_OFFSET)
+                + ((map.ocean_floor() as i64) << (HEIGHTMAP_OFFSET * 2))
+                + ((map.ocean_floor_wg() as i64) << (HEIGHTMAP_OFFSET * 3))
+                + ((map.world_surface() as i64) << (HEIGHTMAP_OFFSET * 4))
+                + ((map.world_surface_wg() as i64) << (HEIGHTMAP_OFFSET * 5))
+        })
+        .collect();
     ChunkRoot {
         level: ChunkLevel {
             x_pos: chunk.position().x,

--- a/core/src/save/region/mod.rs
+++ b/core/src/save/region/mod.rs
@@ -349,12 +349,12 @@ fn read_section_into_chunk(section: &LevelSection, chunk: &mut Chunk) -> Result<
 
 fn chunk_to_chunk_root(chunk: &Chunk, entities: Vec<EntityData>) -> ChunkRoot {
     let heightmaps: Vec<i64> = chunk.heightmaps().iter().map(|map| {
-        (map.motion_blocking() << (9 * 0)
-        + map.motion_blocking_no_leaves() << (9 * 1)
-        + map.ocean_floor() << (9 * 2)
-        + map.ocean_floor_wg() << (9 * 3)
-        + map.world_surface() << (9 * 4)
-        + map.world_surface_wg() << (9 * 5)) as i64
+        (map.motion_blocking() as i64) << (9 * 0)
+        + (map.motion_blocking_no_leaves() as i64) << (9 * 1)
+        + (map.ocean_floor() as i64) << (9 * 2)
+        + (map.ocean_floor_wg() as i64) << (9 * 3)
+        + (map.world_surface() as i64) << (9 * 4)
+        + (map.world_surface_wg() as i64) << (9 * 5)
     }).collect();
     ChunkRoot {
         level: ChunkLevel {

--- a/server/src/worldgen/mod.rs
+++ b/server/src/worldgen/mod.rs
@@ -169,6 +169,8 @@ impl WorldGenerator for ComposableGenerator {
             }
         }
 
+        chunk.recalculate_heightmap();
+
         // Finishers.
         for finisher in &self.finishers {
             finisher.generate_for_chunk(

--- a/server/src/worldgen/superflat.rs
+++ b/server/src/worldgen/superflat.rs
@@ -34,6 +34,9 @@ impl WorldGenerator for SuperflatWorldGenerator {
             }
             y_counter += layer.height;
         }
+
+        chunk.recalculate_heightmap();
+
         chunk
     }
 }


### PR DESCRIPTION
Heightmap that stores 6 different heights as pr [wiki](https://minecraft.gamepedia.com/Chunk_format)
```rust
pub struct HeightMap {
    motion_blocking: usize,
    motion_blocking_no_leaves: usize,
    ocean_floor: usize,
    ocean_floor_wg: usize,
    world_surface: usize,
    world_surface_wg: usize,
}
```
- [x] Update heightmaps on `set_block_at`
- [x] Save heightmaps
- [ ] Load heightmaps
- [ ] World generated heightmap, always stays at 0

I have added `chunk.recalculate_heightmaps()` to chunk generation, not sure if it is correct approch.