### PR TITLE
Disabled jemalloc for msvc toolchain

### DIFF
--- a/core/src/network/mctypes.rs
+++ b/core/src/network/mctypes.rs
@@ -159,14 +159,14 @@ impl<B: Buf + Read> McTypeRead for B {
                 return Err(TryGetError::ValueTooLarge);
             }
             let mut result = String::with_capacity(len as usize);
-            for _ in 0..len {
-                let res = self.try_get_i8()? as u8;
-                result.push(res as char);
-            }
-
+            let _ = self
+                .take(len as u64)
+                .read_to_string(&mut result)
+                .map_err(|_| TryGetError::InvalidValue(-1))?;
+    
             return Ok(result);
         }
-
+    
         Err(TryGetError::NotEnoughBytes)
     }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -94,7 +94,6 @@ itertools = "0.9"
 
 # Allocators
 bumpalo = { version = "3.2", features = ["collections"] }
-jemallocator = "0.3"
 
 # Error handling
 thiserror = "1.0"
@@ -110,3 +109,7 @@ harness = false
 
 [features]
 nightly = ["hashbrown/nightly", "parking_lot/nightly"]
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]   
+#Allocator for everything but msvc
+jemallocator = "0.3"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -125,7 +125,13 @@ use feather_core::level::{deserialize_level_file, save_level_file, LevelData, Le
 use feather_core::world::ChunkMap;
 use feather_core::{level, ChunkPosition};
 use fecs::{EntityBuilder, Executor, Resources, World};
+
+#[cfg(not(target_env = "msvc"))]
 use jemallocator::Jemalloc;
+
+#[cfg(target_env = "msvc")]
+use std::alloc::System;
+
 use rand::Rng;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
@@ -134,9 +140,14 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::process::exit;
 use thread_local::CachedThreadLocal;
-
+//
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static ALLOC: Jemalloc = Jemalloc;
+
+#[cfg(target_env = "msvc")]
+#[global_allocator]
+static ALLOC: System = System;
 
 mod block;
 mod broadcasters;


### PR DESCRIPTION
Feather build fails on msvc toolchain because of jemalloc incompatibilities.