### PR TITLE
Fixed unicode encoding issues in chat

### DIFF
--- a/core/src/network/mctypes.rs
+++ b/core/src/network/mctypes.rs
@@ -159,14 +159,14 @@ impl<B: Buf + Read> McTypeRead for B {
                 return Err(TryGetError::ValueTooLarge);
             }
             let mut result = String::with_capacity(len as usize);
-            for _ in 0..len {
-                let res = self.try_get_i8()? as u8;
-                result.push(res as char);
-            }
-
+            let _ = self
+                .take(len as u64)
+                .read_to_string(&mut result)
+                .map_err(|_| TryGetError::InvalidValue(-1))?;
+    
             return Ok(result);
         }
-
+    
         Err(TryGetError::NotEnoughBytes)
     }
 


### PR DESCRIPTION
Previously any unicode symbol was split to 8 bir chars. Now it's fixed.