### PR TITLE
Initial plugin support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -523,6 +523,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.10",
+ "quote 1.0.1",
+ "strsim 0.9.3",
+ "syn 1.0.18",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote 1.0.1",
+ "syn 1.0.18",
+]
+
+[[package]]
 name = "dashmap"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +658,47 @@ dependencies = [
  "quote 1.0.1",
  "syn 1.0.18",
  "synstructure",
+]
+
+[[package]]
+name = "fapi"
+version = "0.1.0"
+dependencies = [
+ "bstr",
+ "fapi-common",
+ "fapi-macros",
+ "log",
+ "serde_json",
+]
+
+[[package]]
+name = "fapi-common"
+version = "0.1.0"
+dependencies = [
+ "bstr",
+ "log",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "fapi-macros"
+version = "0.1.0"
+dependencies = [
+ "darling",
+ "proc-macro-error",
+ "proc-macro2 1.0.10",
+ "quote 1.0.1",
+ "syn 1.0.18",
+]
+
+[[package]]
+name = "fapi-test-hello-world"
+version = "0.1.0"
+dependencies = [
+ "fapi",
+ "log",
 ]
 
 [[package]]
@@ -1154,10 +1230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "feather_api"
-version = "0.1.0"
-
-[[package]]
 name = "fecs"
 version = "0.1.0"
 source = "git+https://github.com/feather-rs/fecs?rev=fed8bcb516941b12cb980e354e77b699be075a89#fed8bcb516941b12cb980e354e77b699be075a89"
@@ -1579,6 +1651,12 @@ dependencies = [
  "tokio",
  "tokio-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2320,6 +2398,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.10",
+ "quote 1.0.1",
+ "syn 1.0.18",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.1",
+ "syn 1.0.18",
+ "syn-mid",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +2771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+ "serde",
 ]
 
 [[package]]
@@ -2881,6 +2986,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
 name = "strum"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,6 +3064,17 @@ dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.1",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.1",
+ "syn 1.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 members = [
     "api",
+    "api/common",
+    "api/macros",
+    "api/test-plugins/hello-world",
 
     "core",
     "core/anvil",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
-name = "feather_api"
+name = "fapi"
 version = "0.1.0"
 authors = ["caelunshun <caelum12321@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+fapi-common = { path = "common" }
+fapi-macros = { path = "macros" }
+
+serde_json = "1.0"
+bstr = "0.2"
+log = "0.4"

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,15 @@
+`fapi`, the plugin API used for Feather plugins.
+
+# Terminology
+
+"Host" refers to the server executable itself, while "plugin" refers to the plugin dynamic library.
+
+# Contents
+
+`common`: types and functions shared between the host and plugin implementation
+
+`macros`: procedural macros exposed to plugins
+
+`.`: the high-level plugin API exposed to plugins themselves
+
+`test-plugins`: test plugin crates

--- a/api/common/Cargo.toml
+++ b/api/common/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fapi-common"
+version = "0.1.0"
+authors = ["caelunshun <caelunshun@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+semver = { version = "0.9", features = ["serde"] }
+bstr = "0.2"
+log = "0.4"

--- a/api/common/src/event.rs
+++ b/api/common/src/event.rs
@@ -1,0 +1,18 @@
+//! Types associated with events.
+
+/// Unique ID of an event type.
+/// These are allocated opaquely
+/// by the host. No guarantees are made.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct EventId(pub u64);
+
+/// Opaque type representing some avoid.
+///
+/// Pointers to this type may be casted
+/// to a concrete type, given the user
+/// knows the actual type of the event.
+#[repr(C)]
+pub struct OpaqueEvent {
+    _private: [u8; 0],
+}

--- a/api/common/src/lib.rs
+++ b/api/common/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod event;
+pub mod log;
+pub mod states;
+pub mod system;
+pub mod util;
+pub mod vtable;

--- a/api/common/src/log.rs
+++ b/api/common/src/log.rs
@@ -1,0 +1,36 @@
+use log::Level;
+
+/// Level of a log message to print.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<log::Level> for LogLevel {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Debug => LogLevel::Debug,
+            Level::Error => LogLevel::Error,
+            Level::Info => LogLevel::Info,
+            Level::Trace => LogLevel::Trace,
+            Level::Warn => LogLevel::Warn,
+        }
+    }
+}
+
+impl From<LogLevel> for log::Level {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Error => Level::Error,
+            LogLevel::Warn => Level::Warn,
+            LogLevel::Info => Level::Info,
+            LogLevel::Debug => Level::Debug,
+            LogLevel::Trace => Level::Trace,
+        }
+    }
+}

--- a/api/common/src/states.rs
+++ b/api/common/src/states.rs
@@ -1,0 +1,32 @@
+//! To implement the API, the host needs
+//! to access its state in host calls.
+//! To do this, it passes pointers to opaque
+//! types which store some data it needs
+//! to execute API requests.
+//!
+//! There are multiple state types used
+//! at different times in a plugin's lifecycle.
+
+/// The server's state at startup, which the plugin
+/// can use for access to startup functionality such
+/// as the system registry.
+#[repr(C)]
+pub struct StartupState {
+    _private: [u8; 0],
+}
+
+/// The server's state during the execution of a synchronous
+/// task on some region.
+#[repr(C)]
+pub struct GameState {
+    _private: [u8; 0],
+}
+
+/// The server's state potentially outside of the context of a synchronous
+/// region-local task.
+///
+/// Note that an `AsyncState` can be obtained through a `GameState`.
+#[repr(C)]
+pub struct AsyncState {
+    _private: [u8; 0],
+}

--- a/api/common/src/system.rs
+++ b/api/common/src/system.rs
@@ -1,0 +1,23 @@
+//! Defines types for registering systems and event handlers.
+
+use crate::event::{EventId, OpaqueEvent};
+use crate::states::GameState;
+
+/// Specifies a description of a system.
+#[repr(C)]
+pub struct SystemSpec {
+    /// A pointer to the function to run when the system is invoked.
+    pub f: fn(*mut GameState),
+}
+
+/// Specifies a description of an event handler.
+#[repr(C)]
+pub struct HandlerSpec {
+    /// The function to invoke when the handler runs.
+    ///
+    /// The function may assume the `OpaqueEvent` pointer
+    /// points to the event type associated with `event`.
+    pub f: fn(*mut GameState, *mut OpaqueEvent),
+    /// The ID of the event type which is to be handled by `f`.
+    pub event: EventId,
+}

--- a/api/common/src/util.rs
+++ b/api/common/src/util.rs
@@ -1,0 +1,78 @@
+use bstr::BStr;
+use std::alloc::Layout;
+use std::marker::PhantomData;
+use std::slice;
+
+/// A string reference which may be passed over FFI boundaries.
+///
+/// Does not necessarily point to valid UTF8.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct FStr<'a> {
+    ptr: *const u8,
+    len: usize,
+    _lifetime: PhantomData<&'a [u8]>,
+}
+
+impl<'a> From<&'a BStr> for FStr<'a> {
+    fn from(s: &'a BStr) -> Self {
+        let slice: &[u8] = s.as_ref();
+        Self::from(slice)
+    }
+}
+
+impl<'a> From<&'a [u8]> for FStr<'a> {
+    fn from(slice: &'a [u8]) -> Self {
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a> From<&'a str> for FStr<'a> {
+    fn from(string: &'a str) -> Self {
+        Self {
+            ptr: string.as_ptr(),
+            len: string.len(),
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a> From<FStr<'a>> for &'a BStr {
+    fn from(string: FStr<'a>) -> Self {
+        let slice = <&[u8]>::from(string);
+        slice.into()
+    }
+}
+
+impl<'a> From<FStr<'a>> for &'a [u8] {
+    fn from(string: FStr<'a>) -> Self {
+        unsafe { slice::from_raw_parts(string.ptr, string.len) }
+    }
+}
+
+/// An FFI-safe version of `std::allloc::Layout`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct FLayout {
+    size: usize,
+    align: usize,
+}
+
+impl From<Layout> for FLayout {
+    fn from(layout: Layout) -> Self {
+        Self {
+            size: layout.size(),
+            align: layout.align(),
+        }
+    }
+}
+
+impl From<FLayout> for Layout {
+    fn from(layout: FLayout) -> Self {
+        Layout::from_size_align(layout.size, layout.align).unwrap()
+    }
+}

--- a/api/common/src/vtable.rs
+++ b/api/common/src/vtable.rs
@@ -1,0 +1,91 @@
+//! Low-level plumbing used for calls between the host and the plugin.
+//!
+//! # Model
+//! Function calls are split into two categories: _host_ and _plugin_ calls.
+//! A host call consists of a function implemented on the host and called by
+//! the plugin, while a plugin call is the other way around.
+//!
+//! Plugin calls are made by looking up the name of the function in the plugin's
+//! dynamic library. This means functions plugins need to expose directly
+//! to the host need to be marked as `no_mangle` and `extern "C"`.
+//!
+//! Host calls work differently. On initialization, the host passes in a `HostVTable`
+//! which includes the server version, plus _function pointers_ which point to the
+//! host's implementation of the API. To ensure soundness and backwards compatibility,
+//! this vtable is passed between host and plugin using JSON.
+
+use crate::log::LogLevel;
+use crate::states::{AsyncState, GameState, StartupState};
+use crate::system::{HandlerSpec, SystemSpec};
+use crate::util::{FLayout, FStr};
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::export::Formatter;
+use serde::ser::SerializeStruct;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, mem};
+
+#[macro_use]
+mod r#macro;
+
+vtable! {
+    // STARTUP
+    /// Indicates to the host that the plugin and host versions
+    /// are incompatible.
+    ///
+    /// `plugin_version`: JSON-serialized semver `Version`
+    abort_incompatible_versions: fn(state: *mut StartupState, plugin_version: FStr),
+
+    /// Aborts plugin initialization with a custom error.
+    abort_init: fn(state: *mut StartupState, error: FStr),
+
+    /// Registers a system. The system will be run every tick
+    /// during the game.
+    register_system: fn(state: *mut StartupState, spec: SystemSpec),
+
+    /// Registers an event handler. The handle will be invoked
+    /// when events of its type are triggered.
+    register_handler: fn(state: *mut StartupState, spec: HandlerSpec),
+
+    // IN GAME
+    /// Creates a new `AsyncState`, given some `GameState`.
+    ///
+    /// The returned `AsyncState` should be dropped using `drop_async_state`
+    /// when it exits the plugin's scope.
+    create_async_state: fn(state: *mut GameState) -> *mut AsyncState,
+
+    /// Drops an `AsyncState` handle.
+    ///
+    /// This will invalidate the passed pointer.
+    drop_async_state: fn(state: *mut AsyncState),
+
+    // MISC
+    /// Prints a log message with the given level.
+    log: fn(level: LogLevel, msg: FStr, module_path: FStr<'static>),
+
+    // ALLOCATOR FUNCTIONS
+    // These have the same constrants as the
+    // methods for `std::alloc::GlobalAlloc`.
+    /// Allocates a memory region
+    alloc: fn(layout: FLayout) -> *mut u8,
+    /// Deallocates a memory region
+    dealloc: fn(ptr: *mut u8, layout: FLayout),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_vtable_roundtrip() {
+        let vtable = HostVTable::dummy();
+
+        let serialized = serde_json::to_string(&vtable).unwrap();
+        let deserialized: HostVTable = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(vtable.version, deserialized.version);
+        assert_eq!(
+            vtable.log as *const () as usize,
+            deserialized.log as *const () as usize
+        );
+    }
+}

--- a/api/common/src/vtable/macro.rs
+++ b/api/common/src/vtable/macro.rs
@@ -1,0 +1,181 @@
+macro_rules! vtable {
+    ($(
+        $(#[doc = $doc:literal])*
+        $ident:ident: fn($($input_name:ident: $input:ty),*) $(-> $output:ty)?,
+    )* $(,)?) => {
+        #[derive(Clone)]
+        pub struct HostVTable {
+            #[doc = "The version of the host's FAPI implementation."]
+            version: semver::Version,
+            $(
+                $(
+                    #[doc = $doc]
+                )*
+                $ident: extern "C" fn($($input),*) $(-> $output)?,
+            )*
+        }
+
+        impl HostVTable {
+            #[doc = "Returns a dummy vtable whose functions all panic."]
+            pub fn dummy() -> Self {
+                Self {
+                    version: semver::Version::new(1, 0, 0),
+                    $(
+                        $ident: dummy_fns::$ident as _,
+                    )*
+                }
+            }
+
+            $(
+                $(
+                    #[doc = $doc]
+                )*
+                pub unsafe fn $ident(&self, $($input_name: $input),*) $(-> $output)? {
+                    let f = self.$ident;
+                    f($($input_name),*)
+                }
+            )*
+        }
+
+        impl Serialize for HostVTable {
+            fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+            where
+                S: Serializer,
+            {
+                let len = [$(stringify!($ident)),*].len() + 1;
+                let mut state = serializer.serialize_struct("HostVTable", len)?;
+
+                state.serialize_field("version", &self.version)?;
+
+                $(
+                    state.serialize_field(stringify!($ident), &(self.$ident as usize as u64))?;
+                )*
+
+                state.end()
+            }
+        }
+
+        impl <'de> Deserialize<'de> for HostVTable {
+            fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserializer.deserialize_struct("HostVTable", &["version", $(stringify!($ident)),*], HostVTableVisitor)
+            }
+        }
+
+        #[allow(non_camel_case_types)]
+        enum Field {
+            version,
+            $($ident,)*
+        }
+
+        impl <'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error> where D: Deserializer<'de> {
+                struct FieldVisitor;
+
+                impl <'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        write!(formatter, "vtable field")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E> where E: de::Error {
+                        match value {
+                            "version" => Ok(Field::version),
+                            $(
+                                stringify!($ident) => Ok(Field::$ident),
+                            )*
+                            _ => Err(de::Error::unknown_field(value, &[])),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct HostVTableVisitor;
+
+        impl <'de> Visitor<'de> for HostVTableVisitor {
+            type Value = HostVTable;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                write!(formatter, "struct HostVTable")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, <A as SeqAccess<'de>>::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut len = 0;
+                let version = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(len, &self))?;
+
+                $(
+                    len += 1;
+                    let $ident: u64 = seq.next_element()?.ok_or_else(|| de::Error::invalid_length(len, &self))?;
+                    let $ident = unsafe { mem::transmute::<*const (), _>($ident as usize as *const ()) };
+                )*
+
+                Ok(HostVTable {
+                    version,
+                    $(
+                        $ident,
+                    )*
+                })
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<HostVTable, V::Error>
+            where
+                V: MapAccess<'de>,
+            {
+                let mut version = None;
+                $(
+                    let mut $ident = None;
+                )*
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::version => {
+                            if version.is_some() {
+                                return Err(de::Error::duplicate_field("version"));
+                            }
+                            version = Some(map.next_value()?);
+                        }
+                        $(
+                            Field::$ident => {
+                                if $ident.is_some() {
+                                    return Err(de::Error::duplicate_field(stringify!($ident)));
+                                }
+                                $ident = Some(map.next_value()?);
+                            }
+                        )*
+                    }
+                }
+
+                let version = version.ok_or_else(|| de::Error::missing_field("version"))?;
+                $(
+                    let $ident: u64 = $ident.ok_or_else(|| de::Error::missing_field(stringify!($ident)))?;
+                    let $ident = unsafe { mem::transmute::<*const (), _>($ident as usize as *const ()) };
+                )*
+
+                Ok(HostVTable {
+                    version,
+                    $($ident,)*
+                })
+            }
+        }
+
+        #[doc = "Dummy functions for testing vtable functions. All functions panic when called."]
+        mod dummy_fns {
+            use super::*;
+            $(
+                #[allow(unused_variables)]
+                pub extern "C" fn $ident($($input_name: $input),*) $(-> $output)? {
+                    unreachable!()
+                }
+            )*
+        }
+    };
+}

--- a/api/macros/Cargo.toml
+++ b/api/macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fapi-macros"
+version = "0.1.0"
+authors = ["caelunshun <caelunshun@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+proc-macro-error = "1.0"
+darling = "0.10"

--- a/api/macros/src/lib.rs
+++ b/api/macros/src/lib.rs
@@ -1,0 +1,10 @@
+mod plugin;
+
+use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn plugin_init(args: TokenStream, input: TokenStream) -> TokenStream {
+    plugin::plugin(args, input)
+}

--- a/api/macros/src/plugin.rs
+++ b/api/macros/src/plugin.rs
@@ -1,0 +1,84 @@
+use darling::FromMeta;
+use proc_macro_error::*;
+use quote::quote;
+use syn::{parse_macro_input, AttributeArgs};
+use syn::{spanned::Spanned, ItemFn};
+
+#[derive(Debug, FromMeta)]
+struct Args {
+    name: String,
+    description: Option<String>,
+    author: Option<String>,
+}
+
+pub fn plugin(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = {
+        let args = parse_macro_input!(args as AttributeArgs);
+        Args::from_list(&args)
+            .unwrap_or_else(|e| abort_call_site!("failed to parse arguments to plugin: {}", e))
+    };
+    let input = parse_macro_input!(input as ItemFn);
+
+    verify_input(&input);
+
+    let tokens = generate_output(&args, &input);
+    tokens.into()
+}
+
+fn verify_input(input: &ItemFn) {
+    if input.sig.ident != "init" {
+        emit_error!(
+            input.sig.ident.span(),
+            "plugin main function must be called `init`"
+        )
+    }
+
+    if let Some(generic) = input.sig.generics.params.iter().next() {
+        emit_error!(
+            generic.span(),
+            "plugin main function may not have generic parameters"
+        )
+    }
+}
+
+/// Generates the output. This includes setting
+/// the global allocator to delegate to the host,
+/// creating a `__FAPI_INIT__` function called on initialization,
+/// and finally calling the `init` function defined by the plugin.
+/// This also sets the global logging instance, loads the host vtable, and initializes other
+/// states.
+fn generate_output(_args: &Args, input: &ItemFn) -> proc_macro2::TokenStream {
+    quote! {
+        #[cfg_attr(not(test), global_allocator)]
+        static __FAPI_GLOBAL_ALLOCATOR__: ::fapi::alloc::Host = ::fapi::alloc::Host;
+
+        // return value:
+        // 0 => success
+        // 1 => failed to deserialize vtable
+        // 2 => versions not compatible
+        // 3 => init() panicked
+        #[no_mangle]
+        pub extern "C" fn __FAPI_INIT__(state: *mut ::fapi::common::states::StartupState, vtable: ::fapi::common::util::FStr) -> u32 {
+            if let Err(e) = ::fapi::vtable::init_vtable(vtable) {
+                return 1;
+            }
+
+            // TODO: check versions
+            let mut state = ::fapi::StartupState::from(state);
+
+            if ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+                ::fapi::log_crate::set_logger(&::fapi::log::HOST).expect("failed to set logger");
+                init(&mut state);
+            })).is_err() {
+                return 3;
+            }
+
+            0
+        }
+
+        #input
+    }
+}

--- a/api/src/alloc.rs
+++ b/api/src/alloc.rs
@@ -1,0 +1,25 @@
+//! Attempts to make passing allocations between host and plugin safe.
+//!
+//! If a memory block is deallocated with a different allocator than
+//! that it was allocated with, there will be undefined behavior.
+//! By ensuring that all plugin allocations delegate to the host's
+//! allocator, we ensure that the above does not occur.
+//!
+//! The global allocator is set to `Host` by the `plugin` macro.
+
+use crate::vtable::vtable;
+use std::alloc::{GlobalAlloc, Layout};
+
+/// An allocator which delegates to the host's
+/// global allocator.
+pub struct Host;
+
+unsafe impl GlobalAlloc for Host {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        vtable().alloc(layout.into())
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        vtable().dealloc(ptr, layout.into())
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,1 +1,15 @@
+#[doc(hidden)]
+pub mod alloc;
+#[doc(hidden)]
+pub mod log;
+#[doc(hidden)]
+pub mod vtable;
+#[doc(hidden)]
+pub extern crate fapi_common as common;
+#[doc(hidden)]
+pub extern crate log as log_crate;
 
+mod startup;
+
+pub use fapi_macros::plugin_init;
+pub use startup::StartupState;

--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -1,0 +1,30 @@
+use crate::vtable::vtable;
+use fapi_common::log::LogLevel;
+use fapi_common::util::FStr;
+use log::{Log, Metadata, Record};
+
+/// A logging instance which delegates log messages
+/// to the host's logging infrastructure.
+pub struct HostLogger;
+
+pub static HOST: HostLogger = HostLogger;
+
+impl Log for HostLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let level = LogLevel::from(record.level());
+        let msg = format!("{}", record.args());
+        let module_path = record.module_path_static().unwrap_or("");
+
+        unsafe {
+            vtable().log(level, FStr::from(msg.as_str()), module_path.into());
+        }
+    }
+
+    fn flush(&self) {
+        // empty
+    }
+}

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -1,0 +1,16 @@
+use fapi_common::states::StartupState as Inner;
+use std::ptr::NonNull;
+
+/// Represents the state of the server during plugin initialization.
+///
+/// This value allows for registration of systems, event handlers,
+/// and resources. Currently, it is only available at startup,
+/// though this restriction may be relaxed.
+pub struct StartupState(NonNull<Inner>);
+
+#[doc(hidden)]
+impl From<*mut Inner> for StartupState {
+    fn from(inner: *mut Inner) -> Self {
+        StartupState(NonNull::new(inner).expect("startup state was null pointer"))
+    }
+}

--- a/api/src/vtable.rs
+++ b/api/src/vtable.rs
@@ -1,0 +1,29 @@
+use crate::common::util::FStr;
+use fapi_common::vtable::HostVTable;
+
+static mut VTABLE: Option<HostVTable> = None;
+
+/// Intializes the vtable from the given string.
+///
+/// # Safety
+/// This function may not be called from multiple threads
+/// at once.
+pub fn init_vtable(s: FStr) -> Result<(), serde_json::Error> {
+    let vtable = serde_json::from_slice(s.into())?;
+
+    unsafe {
+        VTABLE = Some(vtable);
+    }
+
+    Ok(())
+}
+
+/// Returns a reference to the host vtable.
+///
+/// The vtable must have already been initialized.
+///
+/// # Safety
+/// This call must be made _after_ any calls to `init_vtable`.
+pub fn vtable() -> &'static HostVTable {
+    unsafe { VTABLE.as_ref().expect("vtable not initialized") }
+}

--- a/api/test-plugins/hello-world/Cargo.toml
+++ b/api/test-plugins/hello-world/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fapi-test-hello-world"
+version = "0.1.0"
+authors = ["caelunshun <caelunshun@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+fapi = { path = "../.." }
+log = "0.4"

--- a/api/test-plugins/hello-world/src/lib.rs
+++ b/api/test-plugins/hello-world/src/lib.rs
@@ -1,0 +1,10 @@
+use fapi::{plugin_init, StartupState};
+
+#[plugin_init(
+    name = "HelloWorld",
+    description = "A test plugin",
+    author = "caelunshun"
+)]
+pub fn init(_state: &mut StartupState) {
+    log::info!("Hello world!");
+}


### PR DESCRIPTION
This PR will implement an initial design for `fapi`, our plugin API, and the associated API bindings and plugin loader in `feather-server`.

The current design is based on dynamic loading of shared libraries using a C-compatible FFI interface. The decision was made to hold off on the use of WebAssembly as the WASM ecosystem lacks the maturity we desire. For example, networking is still unimplemented in WASI (and has been for well over a year since the issue was filed...). Networking is a critical feature for plugins needing database interaction.

The current API can be ported to WASM with a bit of effort, should WASI implement the features we need.

Resolves #106, at least initially.

### Checklist

- [x] host vtable abstraction + macro
- [x] `plugin_init` proc macro to mark a plugin's initialization function. (Question: this naming isn't ideal; ideally it would be called `plugin`, but that's taken by the Rust compiler. Other ideas are welcome)
- [x] Plugin logging
- [ ] Test framework to test the API and server implementation
* [ ] Registration of systems
* [ ] Registration of event handlers
* [ ] Interaction with entities and the world
* [ ] Custom components
* [ ] Plugin state
* [ ] Interaction between plugins
* [ ] Documentation
* [ ] Release `fapi` to crates.io