### PR TITLE
Add /me command

### DIFF
--- a/server/commands/src/arguments.rs
+++ b/server/commands/src/arguments.rs
@@ -295,3 +295,9 @@ impl ArgumentKind<CommandCtx> for TextArgument {
         Ok(TextArgument(text.to_owned()))
     }
 }
+
+impl AsRef<str> for TextArgument {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -215,13 +215,12 @@ pub fn say(ctx: &mut CommandCtx, message: TextArgument) -> anyhow::Result<()> {
 }
 
 #[command(usage = "me <action>")]
-pub fn me(ctx: &mut CommandCtx, action: TextArgument) -> anyhow::Result<()> {
-    let name = ctx.world.try_get::<Name>(ctx.sender);
-
-    let sender_name = if let Some(name) = &name { &name.0 } else { "@" };
-    let command_output = Text::from(format!("* {} {}", sender_name, action.0));
-
-    drop(name);
+pub fn me(ctx: &mut CommandCtx, TextArgument(action): TextArgument) -> anyhow::Result<()> {
+    let command_output = {
+        let name = ctx.world.try_get::<Name>(ctx.sender);
+        let sender_name = name.as_ref().map_or("@", |Name(n)| n);
+        Text::from(format!("* {} {}", sender_name, action));
+    };
 
     ctx.game.handle(
         &mut ctx.world,

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -213,3 +213,23 @@ pub fn say(ctx: &mut CommandCtx, message: TextArgument) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[command(usage = "me <action>")]
+pub fn me(ctx: &mut CommandCtx, action: TextArgument) -> anyhow::Result<()> {
+    let name = ctx.world.try_get::<Name>(ctx.sender);
+
+    let sender_name = if let Some(name) = &name { &name.0 } else { "@" };
+    let command_output = Text::from(format!("* {} {}", sender_name, action.0));
+
+    drop(name);
+
+    ctx.game.handle(
+        &mut ctx.world,
+        ChatEvent {
+            message: command_output.into(),
+            position: ChatPosition::Chat,
+        },
+    );
+
+    Ok(())
+}

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -215,11 +215,11 @@ pub fn say(ctx: &mut CommandCtx, message: TextArgument) -> anyhow::Result<()> {
 }
 
 #[command(usage = "me <action>")]
-pub fn me(ctx: &mut CommandCtx, TextArgument(action): TextArgument) -> anyhow::Result<()> {
+pub fn me(ctx: &mut CommandCtx, action: TextArgument) -> anyhow::Result<()> {
     let command_output = {
         let name = ctx.world.try_get::<Name>(ctx.sender);
-        let sender_name = name.as_ref().map_or("@", |Name(n)| n);
-        Text::from(format!("* {} {}", sender_name, action));
+        let sender_name = name.as_deref().map_or("@", |Name(n)| n);
+        Text::from(format!("* {} {}", sender_name, action.as_ref()))
     };
 
     ctx.game.handle(


### PR DESCRIPTION
Adds `/me <action>` command for #229 which is described [here](https://minecraft.gamepedia.com/Commands/me).

This has not been tested on multiple accounts. The text for the command was deduced from running `/me` on a 1.15.2 server from both the console (which appears as `@`) and a normal player account.