### PR TITLE
Implement health, fall damage, and respawning

### DIFF
--- a/core/anvil/src/entity.rs
+++ b/core/anvil/src/entity.rs
@@ -131,6 +131,8 @@ pub struct BaseEntityData {
     pub rotation: ArrayVec<[f32; 2]>,
     #[serde(rename = "Motion")]
     pub velocity: ArrayVec<[f64; 3]>,
+    #[serde(rename = "Health")]
+    pub health: f32,
 }
 
 impl BaseEntityData {
@@ -157,12 +159,13 @@ pub enum EntityLoadError {
 }
 
 impl BaseEntityData {
-    /// Creates a `BaseEntityData` from a position and velocity.
-    pub fn new(pos: Position, velocity: Vec3d) -> Self {
+    /// Creates a `BaseEntityData` from its parameters.
+    pub fn new(pos: Position, velocity: Vec3d, health: f32) -> Self {
         Self {
             position: [pos.x, pos.y, pos.z].into(),
             rotation: [pos.yaw, pos.pitch].into(),
             velocity: [velocity.x, velocity.y, velocity.z].into(),
+            health,
         }
     }
 
@@ -198,6 +201,7 @@ impl Default for BaseEntityData {
             position: [0.0, 0.0, 0.0].into(),
             rotation: [0.0, 0.0].into(),
             velocity: [0.0, 0.0, 0.0].into(),
+            health: 20.0,
         }
     }
 }
@@ -305,6 +309,7 @@ mod tests {
             position: [1.0, 2.0, 3.0].into(),
             rotation: [4.0, 5.0].into(),
             velocity: [6.0, 7.0, 8.0].into(),
+            health: 20.0,
         };
         let pos = data.read_position().unwrap();
 
@@ -322,6 +327,7 @@ mod tests {
             position: [1.0, 2.0, 3.0].into(),
             rotation: [4.0, 5.0].into(),
             velocity: [6.0, 7.0, 8.0].into(),
+            health: 20.0,
         };
         let vel = data.read_velocity().unwrap();
 
@@ -335,7 +341,7 @@ mod tests {
         let pos = position!(1.0, 10.0, 3.0, 115.0, -3.0);
         let vel = vec3(0.0, 1.0, 2.0);
 
-        let data = BaseEntityData::new(pos, vel);
+        let data = BaseEntityData::new(pos, vel, 20.0);
         assert_eq!(data.read_position(), Ok(pos));
         assert_eq!(data.read_velocity(), Ok(vel));
     }

--- a/core/network/src/packet.rs
+++ b/core/network/src/packet.rs
@@ -581,6 +581,11 @@ static PACKET_ID_MAPPINGS: Lazy<AHashMap<PacketId, PacketType>> = Lazy::new(|| {
     );
 
     m.insert(
+        PacketId(0x38, PacketDirection::Clientbound, PacketStage::Play),
+        PacketType::Respawn,
+    );
+
+    m.insert(
         PacketId(0x39, PacketDirection::Clientbound, PacketStage::Play),
         PacketType::EntityHeadLook,
     );

--- a/core/network/src/packet.rs
+++ b/core/network/src/packet.rs
@@ -601,6 +601,11 @@ static PACKET_ID_MAPPINGS: Lazy<AHashMap<PacketId, PacketType>> = Lazy::new(|| {
     );
 
     m.insert(
+        PacketId(0x44, PacketDirection::Clientbound, PacketStage::Play),
+        PacketType::UpdateHealth,
+    );
+
+    m.insert(
         PacketId(0x49, PacketDirection::Clientbound, PacketStage::Play),
         PacketType::SpawnPosition,
     );

--- a/core/network/src/packets.rs
+++ b/core/network/src/packets.rs
@@ -2264,7 +2264,7 @@ pub struct EntityEquipment {
 #[derive(Default, AsAny, Packet, Clone)]
 pub struct UpdateHealth {
     pub health: f32,
-    pub food: i32,
+    pub food: VarInt,
     pub saturation: f32,
 }
 

--- a/core/network/src/packets.rs
+++ b/core/network/src/packets.rs
@@ -306,6 +306,7 @@ pub static IMPL_MAP: Lazy<AHashMap<PacketType, PacketBuilder>> = Lazy::new(|| {
         EntityHeadLook,
         EntityVelocity,
         EntityEquipment,
+        UpdateHealth,
         SpawnPosition,
         TimeUpdate,
         CollectItem,
@@ -2258,6 +2259,13 @@ pub struct EntityEquipment {
     pub entity_id: VarInt,
     pub slot: VarInt,
     pub item: Slot,
+}
+
+#[derive(Default, AsAny, Packet, Clone)]
+pub struct UpdateHealth {
+    pub health: f32,
+    pub food: i32,
+    pub saturation: f32,
 }
 
 // TODO Select Advancement Tab

--- a/server/chunk/src/save.rs
+++ b/server/chunk/src/save.rs
@@ -6,8 +6,8 @@ use feather_core::anvil::player::{InventorySlot, PlayerData};
 use feather_core::inventory::{Inventory, Window};
 use feather_core::util::{ChunkPosition, Gamemode, Position, Vec3d};
 use feather_server_types::{
-    tasks, ChunkLoadEvent, ChunkUnloadEvent, ComponentSerializer, Game, PlayerLeaveEvent, Uuid,
-    TICK_LENGTH, TPS,
+    tasks, ChunkLoadEvent, ChunkUnloadEvent, ComponentSerializer, Game, Health, PlayerLeaveEvent,
+    Uuid, TICK_LENGTH, TPS,
 };
 use fecs::{Entity, World};
 use std::collections::VecDeque;
@@ -162,8 +162,16 @@ pub fn save_player_data(game: &Game, world: &World, player: Entity) {
         })
         .collect();
 
+    let health = world
+        .try_get::<Health>(player)
+        .map(|health| health.0 as f32)
+        .unwrap_or(1.0);
     let data = PlayerData {
-        entity: BaseEntityData::new(*world.get::<Position>(player), Vec3d::broadcast(0.0)),
+        entity: BaseEntityData::new(
+            *world.get::<Position>(player),
+            Vec3d::broadcast(0.0),
+            health,
+        ),
         gamemode: world.get::<Gamemode>(player).id() as i32,
         inventory,
     };

--- a/server/entity/src/fall_damage.rs
+++ b/server/entity/src/fall_damage.rs
@@ -1,0 +1,53 @@
+//! Handles fall damage for entities
+
+use feather_core::util::Position;
+use feather_server_types::{BlocksFallen, BumpVec, CanTakeDamage, Game, Health, PreviousPosition};
+use fecs::{component, Entity, IntoQuery, Read, World, Write};
+use std::cell::RefCell;
+
+/// System which updates `BlocksFallen` for all entities.
+#[fecs::system]
+pub fn update_blocks_fallen(game: &mut Game, world: &mut World) {
+    // Entities who went from !on_ground => on_ground
+
+    // (Legion for_each closures are not FnMuts; no idea why.)
+    let landed = RefCell::new(BumpVec::<Entity>::new_in(game.bump()));
+
+    // TODO: use parallel iterator (blocked on allocator API)
+    // (BumpVec isn't Send.)
+    <(Read<Position>, Read<PreviousPosition>, Write<BlocksFallen>)>::query()
+        .filter(component::<Health>())
+        .filter(component::<CanTakeDamage>())
+        .for_each_entities_mut(
+            world.inner_mut(),
+            |(entity, (pos, prev_pos, mut blocks_fallen))| {
+                match (prev_pos.0.on_ground, pos.on_ground) {
+                    (false, false) => {
+                        // In air: update blocks_fallen
+                        blocks_fallen.0 += (prev_pos.0.y - pos.y).max(0.0);
+                    }
+                    (true, false) => {
+                        // reset blocks_fallen
+                        blocks_fallen.0 = 0.0;
+                    }
+                    (false, true) => {
+                        // landed
+                        landed.borrow_mut().push(entity);
+                    }
+                    _ => (),
+                }
+            },
+        );
+
+    // Damage landed entities
+    for entity in landed.into_inner() {
+        let blocks_fallen = world.get::<BlocksFallen>(entity).0;
+
+        // https://minecraft.gamepedia.com/Damage#Fall_damage
+        let damage = (blocks_fallen - 3.0).max(0.0).round() as u32;
+
+        if damage != 0 {
+            game.damage(entity, damage, world);
+        }
+    }
+}

--- a/server/entity/src/fall_damage.rs
+++ b/server/entity/src/fall_damage.rs
@@ -1,7 +1,9 @@
 //! Handles fall damage for entities
 
 use feather_core::util::Position;
-use feather_server_types::{BlocksFallen, BumpVec, CanTakeDamage, Game, Health, PreviousPosition};
+use feather_server_types::{
+    BlocksFallen, BumpVec, CanTakeDamage, Dead, Game, Health, PreviousPosition,
+};
 use fecs::{component, Entity, IntoQuery, Read, World, Write};
 use std::cell::RefCell;
 
@@ -18,6 +20,7 @@ pub fn update_blocks_fallen(game: &mut Game, world: &mut World) {
     <(Read<Position>, Read<PreviousPosition>, Write<BlocksFallen>)>::query()
         .filter(component::<Health>())
         .filter(component::<CanTakeDamage>())
+        .filter(!component::<Dead>())
         .for_each_entities_mut(
             world.inner_mut(),
             |(entity, (pos, prev_pos, mut blocks_fallen))| {

--- a/server/entity/src/lib.rs
+++ b/server/entity/src/lib.rs
@@ -8,6 +8,7 @@ extern crate feather_core;
 
 mod broadcasters;
 pub mod drops;
+mod fall_damage;
 mod inventory;
 mod mob;
 mod object;
@@ -16,6 +17,7 @@ pub mod particle;
 pub use self::inventory::InventoryExt;
 pub use broadcasters::*;
 pub use drops::on_block_break_drop_loot;
+pub use fall_damage::update_blocks_fallen;
 pub use mob::*;
 pub use object::falling_block::{on_entity_land_remove_falling_block, spawn_falling_blocks};
 pub use object::item::{item_collect, on_item_drop_spawn_item_entity};

--- a/server/entity/src/object/arrow.rs
+++ b/server/entity/src/object/arrow.rs
@@ -51,7 +51,11 @@ fn serialize(_game: &Game, accessor: &EntityRef) -> EntityData {
     let vel = accessor.get::<Velocity>().0;
 
     EntityData::Arrow(ArrowEntityData {
-        entity: BaseEntityData::new(*accessor.get::<Position>(), Vec3d::new(vel.x, vel.y, vel.z)),
+        entity: BaseEntityData::new(
+            *accessor.get::<Position>(),
+            Vec3d::new(vel.x, vel.y, vel.z),
+            1.0,
+        ),
         critical: 0, // TODO
     })
 }

--- a/server/entity/src/object/item.rs
+++ b/server/entity/src/object/item.rs
@@ -10,9 +10,9 @@ use feather_core::network::packets::SpawnObject;
 use feather_core::network::Packet;
 use feather_core::util::{Position, Vec3d};
 use feather_server_types::{
-    ComponentSerializer, EntityLoaderRegistration, EntitySpawnEvent, Game, InventoryUpdateEvent,
-    ItemCollectEvent, ItemDropEvent, NetworkId, PhysicsBuilder, Player, SpawnPacketCreator, Uuid,
-    Velocity, PLAYER_EYE_HEIGHT, TPS,
+    ComponentSerializer, Dead, EntityLoaderRegistration, EntitySpawnEvent, Game,
+    InventoryUpdateEvent, ItemCollectEvent, ItemDropEvent, NetworkId, PhysicsBuilder, Player,
+    SpawnPacketCreator, Uuid, Velocity, PLAYER_EYE_HEIGHT, TPS,
 };
 use feather_server_util::{degrees_to_stops, nearby_entities, protocol_velocity};
 use fecs::{component, EntityBuilder, EntityRef, IntoQuery, Read, World, Write};
@@ -97,6 +97,7 @@ pub fn item_collect(game: &mut Game, world: &mut World) {
     unsafe {
         <(Read<Position>, Write<Inventory>)>::query()
             .filter(component::<Player>())
+            .filter(!component::<Dead>())
             .par_entities_for_each_unchecked(world.inner(), |(player, (pos, mut inventory))| {
                 let inventory: &mut Inventory = &mut *inventory;
 

--- a/server/entity/src/object/item.rs
+++ b/server/entity/src/object/item.rs
@@ -222,7 +222,11 @@ fn serialize(game: &Game, accessor: &EntityRef) -> EntityData {
     let vel = accessor.get::<Velocity>().0;
     let item = accessor.get::<ItemStack>();
     EntityData::Item(ItemEntityData {
-        entity: BaseEntityData::new(*accessor.get::<Position>(), Vec3d::new(vel.x, vel.y, vel.z)),
+        entity: BaseEntityData::new(
+            *accessor.get::<Position>(),
+            Vec3d::new(vel.x, vel.y, vel.z),
+            1.0,
+        ),
         age: 0, // todo
         pickup_delay: (accessor.get::<CollectableAt>().0 as i64 - game.tick_count as i64).max(0)
             as u8,

--- a/server/network/src/worker.rs
+++ b/server/network/src/worker.rs
@@ -235,7 +235,7 @@ async fn load_player_data(config: &Config, uuid: Uuid) -> Result<PlayerData, any
             );
 
             let data = PlayerData {
-                entity: BaseEntityData::new(DEFAULT_POSITION, Vec3d::broadcast(0.0)),
+                entity: BaseEntityData::new(DEFAULT_POSITION, Vec3d::broadcast(0.0), 20.0),
                 gamemode: config.server.default_gamemode.id() as i32,
                 inventory: vec![],
             };

--- a/server/player/src/broadcasters.rs
+++ b/server/player/src/broadcasters.rs
@@ -2,6 +2,7 @@ mod animation;
 mod block;
 mod chat;
 mod gamemode;
+mod health;
 mod keepalive;
 mod teleport;
 
@@ -9,5 +10,6 @@ pub use animation::on_player_animation_broadcast_animation;
 pub use block::*;
 pub use chat::{flush_player_message_receiver, on_chat_broadcast};
 pub use gamemode::*;
+pub use health::on_health_update_send;
 pub use keepalive::broadcast_keepalive;
 pub use teleport::send_teleported;

--- a/server/player/src/broadcasters/health.rs
+++ b/server/player/src/broadcasters/health.rs
@@ -1,0 +1,16 @@
+use feather_core::network::packets::UpdateHealth;
+use feather_server_types::{HealthUpdateEvent, Network};
+use fecs::World;
+
+/// When a player's health is updated, updates it on the client.
+#[fecs::event_handler]
+pub fn on_health_update_send(event: &HealthUpdateEvent, world: &mut World) {
+    if let Some(network) = world.try_get::<Network>(event.entity) {
+        let packet = UpdateHealth {
+            health: event.new as f32,
+            food: 20,        // todo
+            saturation: 5.0, // todo
+        };
+        network.send(packet);
+    }
+}

--- a/server/player/src/death.rs
+++ b/server/player/src/death.rs
@@ -1,6 +1,13 @@
+//! Handles when a player dies.
+//!
+//! Player deaths have some annoying properties which makes a correct implementation difficult.
+//! Most notably, a dead player (one who is currently on the respawn screen) has no physical
+//! presence within the world, despite them still being connected to the server and existing
+//! in that sense.
+
 use entity::drops::drop_item;
 use feather_core::util::Position;
-use feather_server_types::{EntityDeathEvent, Game, Inventory, Player};
+use feather_server_types::{Dead, EntityDeathEvent, Game, Inventory, Player};
 use fecs::World;
 
 /// Scatters a player's items when they die.
@@ -27,5 +34,17 @@ pub fn on_player_death_scatter_inventory(
 
     for item in items_to_spawn {
         drop_item(game, world, item, pos);
+    }
+}
+
+/// Adds the `Dead` component to a player when they die to
+/// avoid causing them to be physically interacted with.
+///
+/// The component will be removed once the user clicks the respawn
+/// button.
+#[fecs::event_handler]
+pub fn on_player_death_mark_dead(event: &EntityDeathEvent, world: &mut World) {
+    if world.has::<Player>(event.entity) {
+        world.add(event.entity, Dead).unwrap();
     }
 }

--- a/server/player/src/death.rs
+++ b/server/player/src/death.rs
@@ -1,0 +1,31 @@
+use entity::drops::drop_item;
+use feather_core::util::Position;
+use feather_server_types::{EntityDeathEvent, Game, Inventory, Player};
+use fecs::World;
+
+/// Scatters a player's items when they die.
+#[fecs::event_handler]
+pub fn on_player_death_scatter_inventory(
+    event: &EntityDeathEvent,
+    game: &mut Game,
+    world: &mut World,
+) {
+    if !world.has::<Player>(event.entity) {
+        return;
+    }
+
+    let inventory = world.get::<Inventory>(event.entity);
+    let pos = *world.get::<Position>(event.entity);
+
+    // Remove items and drop on ground
+    let items_to_spawn = inventory
+        .iter_mut()
+        .filter_map(|mut item| item.take())
+        .collect::<Vec<_>>();
+
+    drop(inventory);
+
+    for item in items_to_spawn {
+        drop_item(game, world, item, pos);
+    }
+}

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -16,10 +16,11 @@ use feather_core::text::Text;
 use feather_core::util::{Gamemode, Position};
 use feather_server_network::NewClientInfo;
 use feather_server_types::{
-    CanBreak, CanInstaBreak, CanTakeDamage, ChunkHolder, CreationPacketCreator, EntitySpawnEvent,
-    Game, GamemodeUpdateEvent, HeldItem, InventoryUpdateEvent, LastKnownPositions, MessageReceiver,
-    Name, Network, NetworkId, Player, PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition,
-    ProfileProperties, SpawnPacketCreator, Uuid,
+    CanBreak, CanInstaBreak, CanRespawn, CanTakeDamage, ChunkHolder, CreationPacketCreator,
+    EntitySpawnEvent, Game, GamemodeUpdateEvent, Health, HeldItem, InventoryUpdateEvent,
+    LastKnownPositions, MaxHealth, MessageReceiver, Name, Network, NetworkId, Player,
+    PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition, ProfileProperties, SpawnPacketCreator,
+    Uuid,
 };
 use feather_server_util::degrees_to_stops;
 use fecs::{Entity, EntityRef, World};
@@ -110,6 +111,10 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
     world.add(entity, MessageReceiver::default()).unwrap();
 
     world.add(entity, Player).unwrap();
+
+    world.add(entity, CanRespawn).unwrap();
+    world.add(entity, MaxHealth(20)).unwrap();
+    world.add(entity, Health(20)).unwrap(); // TODO: load from player data
 
     game.player_count.fetch_add(1, Ordering::SeqCst);
     game.handle(world, EntitySpawnEvent { entity });

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -28,7 +28,7 @@ use fecs::{Entity, EntityRef, World};
 
 pub use broadcasters::*;
 pub use chat::*;
-pub use death::on_player_death_scatter_inventory;
+pub use death::*;
 pub use join::*;
 pub use packet_handlers::*;
 use std::sync::atomic::Ordering;

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -18,9 +18,9 @@ use feather_core::util::{Gamemode, Position};
 use feather_server_network::NewClientInfo;
 use feather_server_types::{
     BlocksFallen, CanBreak, CanInstaBreak, CanRespawn, CanTakeDamage, ChunkHolder,
-    CreationPacketCreator, EntitySpawnEvent, Game, GamemodeUpdateEvent, Health, HeldItem,
-    InventoryUpdateEvent, LastKnownPositions, MaxHealth, MessageReceiver, Name, Network, NetworkId,
-    Player, PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition, ProfileProperties,
+    CreationPacketCreator, EntitySpawnEvent, Game, GamemodeUpdateEvent, Health, HealthUpdateEvent,
+    HeldItem, InventoryUpdateEvent, LastKnownPositions, MaxHealth, MessageReceiver, Name, Network,
+    NetworkId, Player, PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition, ProfileProperties,
     SpawnPacketCreator, Uuid,
 };
 use feather_server_util::degrees_to_stops;
@@ -116,7 +116,9 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
 
     world.add(entity, CanRespawn).unwrap();
     world.add(entity, MaxHealth(20)).unwrap();
-    world.add(entity, Health(20)).unwrap(); // TODO: load from player data
+    world
+        .add(entity, Health(info.data.entity.health as u32))
+        .unwrap();
     world.add(entity, BlocksFallen::default()).unwrap();
 
     game.player_count.fetch_add(1, Ordering::SeqCst);
@@ -128,6 +130,14 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
         InventoryUpdateEvent {
             slots: slots.collect(),
             player: entity,
+        },
+    );
+    game.handle(
+        world,
+        HealthUpdateEvent {
+            old: 0,
+            new: info.data.entity.health as u32,
+            entity,
         },
     );
 

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -16,11 +16,11 @@ use feather_core::text::Text;
 use feather_core::util::{Gamemode, Position};
 use feather_server_network::NewClientInfo;
 use feather_server_types::{
-    CanBreak, CanInstaBreak, CanRespawn, CanTakeDamage, ChunkHolder, CreationPacketCreator,
-    EntitySpawnEvent, Game, GamemodeUpdateEvent, Health, HeldItem, InventoryUpdateEvent,
-    LastKnownPositions, MaxHealth, MessageReceiver, Name, Network, NetworkId, Player,
-    PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition, ProfileProperties, SpawnPacketCreator,
-    Uuid,
+    BlocksFallen, CanBreak, CanInstaBreak, CanRespawn, CanTakeDamage, ChunkHolder,
+    CreationPacketCreator, EntitySpawnEvent, Game, GamemodeUpdateEvent, Health, HeldItem,
+    InventoryUpdateEvent, LastKnownPositions, MaxHealth, MessageReceiver, Name, Network, NetworkId,
+    Player, PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition, ProfileProperties,
+    SpawnPacketCreator, Uuid,
 };
 use feather_server_util::degrees_to_stops;
 use fecs::{Entity, EntityRef, World};
@@ -115,6 +115,7 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
     world.add(entity, CanRespawn).unwrap();
     world.add(entity, MaxHealth(20)).unwrap();
     world.add(entity, Health(20)).unwrap(); // TODO: load from player data
+    world.add(entity, BlocksFallen::default()).unwrap();
 
     game.player_count.fetch_add(1, Ordering::SeqCst);
     game.handle(world, EntitySpawnEvent { entity });

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -4,6 +4,7 @@ extern crate nalgebra_glm as glm;
 
 mod broadcasters;
 mod chat;
+mod death;
 mod join;
 mod packet_handlers;
 mod view;
@@ -27,6 +28,7 @@ use fecs::{Entity, EntityRef, World};
 
 pub use broadcasters::*;
 pub use chat::*;
+pub use death::on_player_death_scatter_inventory;
 pub use join::*;
 pub use packet_handlers::*;
 use std::sync::atomic::Ordering;

--- a/server/player/src/packet_handlers.rs
+++ b/server/player/src/packet_handlers.rs
@@ -2,6 +2,7 @@
 
 mod animation;
 mod chat;
+mod client_status;
 mod digging;
 mod inventory;
 mod movement;
@@ -10,6 +11,7 @@ mod use_item;
 
 pub use animation::handle_animation;
 pub use chat::handle_chat;
+pub use client_status::handle_client_status;
 pub use digging::*;
 use fecs::{Entity, World};
 pub use inventory::*;

--- a/server/player/src/packet_handlers/client_status.rs
+++ b/server/player/src/packet_handlers/client_status.rs
@@ -1,0 +1,30 @@
+use crate::packet_handlers::IteratorExt;
+use feather_core::network::packets::ClientStatus;
+use feather_core::util::Position;
+use feather_server_types::{Dead, Health, PacketBuffers, Teleported};
+use fecs::World;
+use std::sync::Arc;
+
+/// Handles the Client Status packet, which is sent
+/// when the user clicks the respawn button.
+#[fecs::system]
+pub fn handle_client_status(world: &mut World, packet_buffers: &Arc<PacketBuffers>) {
+    packet_buffers
+        .received::<ClientStatus>()
+        .for_each_valid(world, |world, (player, packet)| {
+            match packet.action_id {
+                0 => {
+                    // Perform respawn
+                    let _ = world.remove::<Dead>(player);
+
+                    // TODO: support spawn positons
+                    *world.get_mut::<Position>(player) = Position::default();
+
+                    world.get_mut::<Health>(player).0 = 20;
+
+                    world.add(player, Teleported).unwrap();
+                }
+                x => log::debug!("Unimplemented Client Status action ID {}", x),
+            }
+        });
+}

--- a/server/player/src/packet_handlers/client_status.rs
+++ b/server/player/src/packet_handlers/client_status.rs
@@ -1,7 +1,8 @@
 use crate::packet_handlers::IteratorExt;
 use feather_core::network::packets::ClientStatus;
-use feather_core::util::Position;
-use feather_server_types::{Dead, Health, PacketBuffers, Teleported};
+use feather_core::network::packets::Respawn;
+use feather_core::util::{Gamemode, Position};
+use feather_server_types::{Dead, Health, Network, PacketBuffers, Teleported};
 use fecs::World;
 use std::sync::Arc;
 
@@ -23,6 +24,17 @@ pub fn handle_client_status(world: &mut World, packet_buffers: &Arc<PacketBuffer
                     world.get_mut::<Health>(player).0 = 20;
 
                     world.add(player, Teleported).unwrap();
+
+                    let gamemode = *world.get::<Gamemode>(player);
+
+                    // Send Respawn packet
+                    let packet = Respawn {
+                        dimension: 0,
+                        difficulty: 1,
+                        gamemode: gamemode.id() as u8,
+                        level_type: String::from("default"),
+                    };
+                    world.get::<Network>(player).send(packet);
                 }
                 x => log::debug!("Unimplemented Client Status action ID {}", x),
             }

--- a/server/src/event_handlers.rs
+++ b/server/src/event_handlers.rs
@@ -88,5 +88,7 @@ pub fn build_event_handlers() -> EventHandlers {
         on_gamemode_update_send,
 
         on_health_update_send,
+
+        on_player_death_scatter_inventory,
     }
 }

--- a/server/src/event_handlers.rs
+++ b/server/src/event_handlers.rs
@@ -90,5 +90,6 @@ pub fn build_event_handlers() -> EventHandlers {
         on_health_update_send,
 
         on_player_death_scatter_inventory,
+        on_player_death_mark_dead,
     }
 }

--- a/server/src/event_handlers.rs
+++ b/server/src/event_handlers.rs
@@ -86,5 +86,7 @@ pub fn build_event_handlers() -> EventHandlers {
 
         on_gamemode_update_update_capabilities,
         on_gamemode_update_send,
+
+        on_health_update_send,
     }
 }

--- a/server/src/systems.rs
+++ b/server/src/systems.rs
@@ -37,6 +37,7 @@ pub fn build_executor() -> Executor {
         .with(player::check_crossed_chunks)
         .with(player::broadcast_keepalive)
         .with(entity::broadcast_movement)
+        .with(entity::update_blocks_fallen)
         .with(entity::broadcast_velocity)
         .with(entity::falling_block::spawn_falling_blocks)
         .with(chunk_logic::chunk_save)

--- a/server/src/systems.rs
+++ b/server/src/systems.rs
@@ -25,6 +25,7 @@ pub fn build_executor() -> Executor {
         .with(player::handle_player_digging)
         .with(player::advance_dig_progress)
         .with(player::broadcast_block_break_animation)
+        .with(player::handle_client_status)
         .with(player::handle_chat)
         .with(player::flush_player_message_receiver)
         .with(game::task::run_sync_tasks)

--- a/server/test/src/unit.rs
+++ b/server/test/src/unit.rs
@@ -188,7 +188,7 @@ impl Test {
             profile: vec![],
             uuid: Uuid::new_v4(),
             data: PlayerData {
-                entity: BaseEntityData::new(position, vec3(0.0, 0.0, 0.0)),
+                entity: BaseEntityData::new(position, vec3(0.0, 0.0, 0.0), 20.0),
                 gamemode: 1,
                 inventory: vec![],
             },

--- a/server/types/src/components.rs
+++ b/server/types/src/components.rs
@@ -104,3 +104,12 @@ impl MessageReceiver {
         self.buffer.drain(..)
     }
 }
+
+/// Health of an entity. Measured in "half-hearts."
+#[derive(Copy, Clone, Debug)]
+pub struct Health(pub u32);
+
+/// Maximum health of an entity under normal conditions (i.e. excluding potion effects
+/// such as absorption.)
+#[derive(Copy, Clone, Debug)]
+pub struct MaxHealth(pub u32);

--- a/server/types/src/components.rs
+++ b/server/types/src/components.rs
@@ -113,3 +113,8 @@ pub struct Health(pub u32);
 /// such as absorption.)
 #[derive(Copy, Clone, Debug)]
 pub struct MaxHealth(pub u32);
+
+/// Stores the number of blocks fallen by an entity
+/// since the last time they were on_ground.
+#[derive(Default, Copy, Clone, Debug)]
+pub struct BlocksFallen(pub f64);

--- a/server/types/src/components/marker.rs
+++ b/server/types/src/components/marker.rs
@@ -20,3 +20,9 @@ pub struct CanBreak;
 ///
 /// Only necessary for players.
 pub struct Teleported;
+
+/// Whether an entity is able to respawn.
+///
+/// If this component is added, then the entity
+/// will not be removed from the `World` when it dies.
+pub struct CanRespawn;

--- a/server/types/src/components/marker.rs
+++ b/server/types/src/components/marker.rs
@@ -26,3 +26,9 @@ pub struct Teleported;
 /// If this component is added, then the entity
 /// will not be removed from the `World` when it dies.
 pub struct CanRespawn;
+
+/// Component for players who are currently on the respawn screen.
+///
+/// Players with this component _should not be affected by gameplay actions_.
+/// They should not collect items, take damage, etc.
+pub struct Dead;

--- a/server/types/src/events.rs
+++ b/server/types/src/events.rs
@@ -35,6 +35,15 @@ pub struct EntityDespawnEvent {
     pub entity: Entity,
 }
 
+/// Triggered when an entity is killed.
+///
+/// Always triggered _before_ `EntityDespawnEvent`
+/// if the entity is despawned as well.
+#[derive(Copy, Clone, Debug)]
+pub struct EntityDeathEvent {
+    pub entity: Entity,
+}
+
 /// Triggered when a chunk is sent to a player.
 #[derive(Copy, Clone, Debug)]
 pub struct ChunkSendEvent {
@@ -116,6 +125,17 @@ pub struct InventoryUpdateEvent {
 /// Event triggered when an entity is created.
 #[derive(Copy, Clone, Debug)]
 pub struct EntitySpawnEvent {
+    pub entity: Entity,
+}
+
+/// Event triggered when an entity's health is updated.
+#[derive(Copy, Clone, Debug)]
+pub struct HealthUpdateEvent {
+    /// The old health.
+    pub old: u32,
+    /// The new health.
+    pub new: u32,
+    /// The entity whose health was updated.
     pub entity: Entity,
 }
 

--- a/server/types/src/game.rs
+++ b/server/types/src/game.rs
@@ -1,5 +1,8 @@
 use crate::{BlockUpdateCause, Network, ServerToWorkerMessage};
-use crate::{BlockUpdateEvent, EntityDespawnEvent, Name, PlayerLeaveEvent};
+use crate::{
+    BlockUpdateEvent, CanRespawn, EntityDeathEvent, EntityDespawnEvent, Health, HealthUpdateEvent,
+    Name, PlayerLeaveEvent,
+};
 use ahash::AHashMap;
 use bumpalo::Bump;
 use feather_core::anvil::level::LevelData;
@@ -226,6 +229,54 @@ impl Game {
         // Send the packet to all players who have a hold on the entity's chunk.
         let entity_chunk = world.get::<Position>(entity).chunk();
         self.broadcast_chunk_update_boxed(world, packet, entity_chunk, neq);
+    }
+
+    /// Applies damage to the given entity. Handles all logic,
+    /// including killing the entity if its health drops below 1.
+    pub fn damage(&mut self, entity: Entity, damage: u32, world: &mut World) {
+        let (should_kill, old_health, new_health) =
+            if let Some(mut health) = world.try_get_mut::<Health>(entity) {
+                let old_health = health.0;
+                let should_kill = match health.0.checked_sub(damage) {
+                    Some(0) => true,
+                    None => {
+                        // below 0
+                        health.0 = 0;
+                        true
+                    }
+                    Some(new_health) => {
+                        health.0 = new_health;
+                        false
+                    }
+                };
+                let new_health = health.0;
+                (should_kill, Some(old_health), new_health)
+            } else {
+                (false, None, 0)
+            };
+
+        if let Some(old_health) = old_health {
+            self.handle(
+                world,
+                HealthUpdateEvent {
+                    old: old_health,
+                    new: new_health,
+                    entity,
+                },
+            );
+        }
+
+        if should_kill {
+            self.kill(entity, world);
+        }
+    }
+
+    /// Kills an entity.
+    pub fn kill(&mut self, entity: Entity, world: &mut World) {
+        self.handle(world, EntityDeathEvent { entity });
+        if !world.has::<CanRespawn>(entity) {
+            self.despawn(entity, world);
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements entity health (components + base functionality), fall damage, and respawning of clients.

Note that healing is not implemented, as it requires hunger to work first.

* [x] Base health functionality
* [x] Fall damage
* [x] Drop items upon death
* [x] Save health in player data
* [x] Respawning of clients (sent in Client Status packet)

Resolves #245.
Resolves #246.