### PR TITLE
Remove divide-by-zero issue when logging time spent optimizing each section

### DIFF
--- a/server/chunk/src/chunk_manager.rs
+++ b/server/chunk/src/chunk_manager.rs
@@ -234,11 +234,16 @@ pub fn chunk_optimize(game: &mut Game) {
     let end_time = current_time_in_millis();
     let elapsed = end_time - start_time;
 
+    let num_sections = count.load(Ordering::Relaxed);
     log::debug!(
-        "Optimized {} chunk sections (took {}ms - {:.2}ms/section)",
-        count.load(Ordering::Relaxed),
+        "Optimized {} chunk sections (took {}ms{})",
+        num_sections,
         elapsed,
-        elapsed as f64 / f64::from(count.load(Ordering::Relaxed))
+        if num_sections == 0 {
+            String::new()
+        } else {
+            format!(" - {:.2}ms/section", elapsed as f64 / num_sections as f64)
+        }
     );
 }
 


### PR DESCRIPTION
This solves the NaN and infinity issue shown at the end here when I ran the server:
```
2020-05-29 15:15:28,772 DEBUG [feather_server_chunk::chunk_manager] Optimizing chunks
2020-05-29 15:15:28,773 DEBUG [feather_server_chunk::chunk_manager] Optimized 0 chunk sections (took 1ms - infms/section)
2020-05-29 15:20:28,803 DEBUG [feather_server_chunk::chunk_manager] Optimizing chunks
2020-05-29 15:20:28,803 DEBUG [feather_server_chunk::chunk_manager] Optimized 0 chunk sections (took 0ms - NaNms/section)
```