### PR TITLE
Implement /stop command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "bumpalo",
+ "crossbeam",
  "dashmap",
  "feather-core",
  "feather-server-config",

--- a/core/text/src/lib.rs
+++ b/core/text/src/lib.rs
@@ -384,6 +384,16 @@ impl TextValue {
         TextValue::Text { text: text.into() }
     }
 
+    pub fn translate<A>(translate: A) -> Self
+    where
+        A: Into<Translate>,
+    {
+        TextValue::Translate {
+            translate: translate.into(),
+            with: Default::default(),
+        }
+    }
+
     pub fn translate_with<A, B>(translate: A, with: B) -> Self
     where
         A: Into<Translate>,

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -5,12 +5,13 @@ use crate::{
     arguments::{EntitySelector, ParsedGamemode, TextArgument},
     CommandCtx,
 };
-use feather_core::text::{Text, TextComponentBuilder};
+use feather_core::text::{Text, TextComponentBuilder, TextValue};
 use feather_core::util::{Gamemode, Position};
 use feather_server_types::{
-    ChatEvent, ChatPosition, GamemodeUpdateEvent, MessageReceiver, Name, Teleported,
+    ChatEvent, ChatPosition, GamemodeUpdateEvent, MessageReceiver, Name, ShutdownChannels,
+    Teleported,
 };
-use fecs::{Entity, World};
+use fecs::{Entity, ResourcesProvider, World};
 use lieutenant::command;
 use thiserror::Error;
 
@@ -229,6 +230,25 @@ pub fn me(ctx: &mut CommandCtx, action: TextArgument) -> anyhow::Result<()> {
             position: ChatPosition::Chat,
         },
     );
+
+    Ok(())
+}
+
+#[command(usage = "stop")]
+pub fn stop(ctx: &mut CommandCtx) -> anyhow::Result<()> {
+    // Confirmation message
+    // TODO Server ops should also see the message
+    if let Some(mut sender_message_receiver) = ctx.world.try_get_mut::<MessageReceiver>(ctx.sender)
+    {
+        let text = Text::from(TextValue::translate("commands.stop.stopping"));
+        sender_message_receiver.send(text);
+    }
+
+    ctx.game
+        .resources
+        .get::<ShutdownChannels>()
+        .tx
+        .try_send(())?;
 
     Ok(())
 }

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -106,8 +106,9 @@ impl CommandState {
                 gamemode_2,
 
                 whisper,
-
                 say,
+
+                stop,
         }
 
         Self {

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -8,7 +8,7 @@ use feather_server_chunk::{chunk_worker, ChunkWorkerHandle};
 use feather_server_config::DEFAULT_CONFIG_STR;
 use feather_server_network::NetworkIoManager;
 use feather_server_packet_buffer::PacketBuffers;
-use feather_server_types::{task, Config, Game, Shared};
+use feather_server_types::{task, Config, Game, Shared, ShutdownChannels};
 use feather_server_worldgen::{
     ComposableGenerator, EmptyWorldGenerator, SuperflatWorldGenerator, WorldGenerator,
 };
@@ -308,7 +308,8 @@ fn create_resources(
             .with(game)
             .with(cworker_handle)
             .with(networking_handle)
-            .with(packet_buffers);
+            .with(packet_buffers)
+            .with(ShutdownChannels::new());
         Arc::new(resources)
     };
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -4,7 +4,7 @@
 
 use feather_server_chunk::ChunkWorkerHandle;
 use feather_server_lighting::LightingWorkerHandle;
-use feather_server_types::{Game, TPS};
+use feather_server_types::{Game, ShutdownChannels, TPS};
 use fecs::{Executor, OwnedResources, ResourcesProvider, World};
 use spin_sleep::LoopHelper;
 use std::ops::Deref;
@@ -38,9 +38,11 @@ pub async fn main(runtime: runtime::Handle) {
         }
     };
 
-    // Channels used by the shutdown handler thread
-    // to notify server thread of shutdown
-    let (shutdown_tx, shutdown_rx) = crossbeam::bounded(1);
+    // Shutdown channels from wrapper resource are used to notify server thread of shutdown
+    let (shutdown_tx, shutdown_rx) = {
+        let channels = resources.get::<ShutdownChannels>();
+        (channels.tx.clone(), channels.rx.clone())
+    };
     shutdown::init(shutdown_tx);
 
     let state = FullState {

--- a/server/src/shutdown.rs
+++ b/server/src/shutdown.rs
@@ -11,10 +11,7 @@ use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 pub fn init(tx: crossbeam::Sender<()>) {
-    ctrlc::set_handler(move || {
-        tx.send(()).unwrap();
-    })
-    .unwrap();
+    ctrlc::set_handler(move || tx.try_send(()).unwrap()).unwrap();
 }
 
 pub fn disconnect_players(world: &World) -> anyhow::Result<()> {

--- a/server/src/shutdown.rs
+++ b/server/src/shutdown.rs
@@ -1,7 +1,7 @@
 //! Shutdown behavior.
 use anyhow::Context;
 use feather_core::network::packets::DisconnectPlay;
-use feather_core::text::{Text, TextRoot};
+use feather_core::text::{TextRoot, TextValue};
 use feather_server_chunk::chunk_worker::Request;
 use feather_server_chunk::{save_chunk_at, ChunkWorkerHandle};
 use feather_server_lighting::LightingWorkerHandle;
@@ -20,7 +20,10 @@ pub fn init(tx: crossbeam::Sender<()>) {
 pub fn disconnect_players(world: &World) -> anyhow::Result<()> {
     <Read<Network>>::query().for_each(world.inner(), |network| {
         let packet = DisconnectPlay {
-            reason: TextRoot::from(Text::from("Server closed")).into(),
+            reason: TextRoot::from(TextValue::translate(
+                "multiplayer.disconnect.server_shutdown",
+            ))
+            .into(),
         };
 
         network.send(packet);

--- a/server/types/Cargo.toml
+++ b/server/types/Cargo.toml
@@ -28,3 +28,4 @@ futures = "0.3"
 tokio = { version = "0.2", features = ["full"] }
 mojang-api = "0.6"
 once_cell = "1.3"
+crossbeam = "0.7"

--- a/server/types/src/misc.rs
+++ b/server/types/src/misc.rs
@@ -39,3 +39,17 @@ impl EntityLoaderRegistration {
 }
 
 inventory::collect!(EntityLoaderRegistration);
+
+/// Wrapper around the send/receive channels which will be used to
+/// notify server thread of shutdown due to ctrl+C or /stop command.
+pub struct ShutdownChannels {
+    pub tx: crossbeam::channel::Sender<()>,
+    pub rx: crossbeam::channel::Receiver<()>,
+}
+
+impl ShutdownChannels {
+    pub fn new() -> Self {
+        let (tx, rx) = crossbeam::bounded(1);
+        Self { tx, rx }
+    }
+}

--- a/server/types/src/misc.rs
+++ b/server/types/src/misc.rs
@@ -53,3 +53,9 @@ impl ShutdownChannels {
         Self { tx, rx }
     }
 }
+
+impl Default for ShutdownChannels {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
For #229

I also added the `TextValue::translate` fn to use for translate keys which don't need replacement, like "stopping server" or "server closed".

Of course, let me know if there could be improvements anywhere :)