### PR TITLE
Prevent shooting a bow from crashing the server

### DIFF
--- a/server/player/src/packet_handlers/digging.rs
+++ b/server/player/src/packet_handlers/digging.rs
@@ -443,7 +443,7 @@ fn find_arrow(inventory: &Inventory) -> Option<(SlotIndex, ItemStack)> {
         }
     }
 
-    for inv_slot in 0..=27 {
+    for inv_slot in 0..27 {
         if let Some(inv_stack) = inventory.item_at(Area::Main, inv_slot).unwrap() {
             if is_arrow_item(inv_stack.ty) {
                 return Some((slot(Area::Main, inv_slot), inv_stack));


### PR DESCRIPTION
Fixed a small typo in `feather-server-player::packet_handlers::find_arrow`.

Resolves  #263.