### PR TITLE
Fix various world loading problems (Issue #265)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "feather-util",
  "hematite-nbt",
  "serde",
+ "serde_test",
  "thiserror",
  "tokio",
  "uuid",
@@ -2915,18 +2916,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 dependencies = [
  "proc-macro2 1.0.17",
  "quote 1.0.1",
@@ -2941,6 +2942,15 @@ checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326d93a77b25d5516844911b9df1d02375405a5b2671c1d23b0fbd9ac7af4f3"
+dependencies = [
  "serde",
 ]
 

--- a/core/anvil/Cargo.toml
+++ b/core/anvil/Cargo.toml
@@ -14,7 +14,7 @@ feather-util = { path = "../util" }
 
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["full"] }
-serde = "1.0"
+serde = "1.0.112" # >= 1.0.112 needed for a fix in #[serde(flatten)]
 uuid = "0.8"
 hematite-nbt = "0.4"
 byteorder = "1.3"

--- a/core/anvil/Cargo.toml
+++ b/core/anvil/Cargo.toml
@@ -21,3 +21,6 @@ byteorder = "1.3"
 bitvec = "0.17"
 anyhow = "1.0"
 arrayvec = { version = "0.5", features = ["serde"] }
+
+[dev-dependencies]
+"serde_test" = "1.0.112"

--- a/core/anvil/src/block_entity.rs
+++ b/core/anvil/src/block_entity.rs
@@ -157,7 +157,6 @@ pub enum BlockEntityKind {
     #[serde(rename_all = "PascalCase")]
     Jukebox { record_item: InventorySlot },
     // TODO: a few more
-
     /// Fallback type for unknown block entities
     #[serde(other)]
     Unknown,

--- a/core/anvil/src/block_entity.rs
+++ b/core/anvil/src/block_entity.rs
@@ -59,11 +59,6 @@ pub struct BlockEntityBase {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "id")]
 pub enum BlockEntityKind {
-    #[serde(rename = "minecraft:banner")]
-    #[serde(rename_all = "PascalCase")]
-    Banner {
-        // TODO
-    },
     #[serde(rename = "minecraft:beacon")]
     #[serde(rename_all = "PascalCase")]
     Beacon {
@@ -161,18 +156,16 @@ pub enum BlockEntityKind {
     #[serde(rename = "minecraft:jukebox")]
     #[serde(rename_all = "PascalCase")]
     Jukebox { record_item: InventorySlot },
-    #[serde(rename = "minecraft:mob_spawner")]
-    #[serde(rename_all = "PascalCase")]
-    MobSpawner {
-        // TODO
-    },
     // TODO: a few more
+
+    /// Fallback type for unknown block entities
+    #[serde(other)]
+    Unknown,
 }
 
 impl BlockEntityKind {
     pub fn variant(&self) -> BlockEntityVariant {
         match self {
-            BlockEntityKind::Banner { .. } => BlockEntityVariant::Banner,
             BlockEntityKind::Beacon { .. } => BlockEntityVariant::Beacon,
             BlockEntityKind::Bed { .. } => BlockEntityVariant::Bed,
             BlockEntityKind::BrewingStand { .. } => BlockEntityVariant::BrewingStand,
@@ -191,7 +184,7 @@ impl BlockEntityKind {
             BlockEntityKind::Hopper { .. } => BlockEntityVariant::Hopper,
             BlockEntityKind::Jigsaw { .. } => BlockEntityVariant::Jigsaw,
             BlockEntityKind::Jukebox { .. } => BlockEntityVariant::Jukebox,
-            BlockEntityKind::MobSpawner { .. } => BlockEntityVariant::MobSpawner,
+            BlockEntityKind::Unknown { .. } => BlockEntityVariant::Unknown,
         }
     }
 }
@@ -199,7 +192,6 @@ impl BlockEntityKind {
 /// Variant of a `BlockEntityKind`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BlockEntityVariant {
-    Banner,
     Beacon,
     Bed,
     BrewingStand,
@@ -218,5 +210,5 @@ pub enum BlockEntityVariant {
     Hopper,
     Jigsaw,
     Jukebox,
-    MobSpawner,
+    Unknown,
 }

--- a/core/anvil/src/block_entity.rs
+++ b/core/anvil/src/block_entity.rs
@@ -58,23 +58,31 @@ pub struct BlockEntityBase {
 /// Kind of a block entity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "id")]
-#[serde(rename_all = "PascalCase")]
 pub enum BlockEntityKind {
+    #[serde(rename = "minecraft:banner")]
+    #[serde(rename_all = "PascalCase")]
+    Banner {
+        // TODO
+    },
     #[serde(rename = "minecraft:beacon")]
+    #[serde(rename_all = "PascalCase")]
     Beacon {
         levels: i32,
         primary: i32,
         secondary: i32,
     },
     #[serde(rename = "minecraft:bed")]
+    #[serde(rename_all = "PascalCase")]
     Bed, // empty in JE
     #[serde(rename = "minecraft:brewing_stand")]
+    #[serde(rename_all = "PascalCase")]
     BrewingStand {
         items: Vec<InventorySlot>,
         brew_time: i16,
         fuel: i8,
     },
     #[serde(rename = "minecraft:cauldron")]
+    #[serde(rename_all = "PascalCase")]
     Cauldron {
         items: Vec<InventorySlot>,
         potion_id: i16,
@@ -82,15 +90,18 @@ pub enum BlockEntityKind {
         is_movable: bool,
     },
     #[serde(rename = "minecraft:chest")]
+    #[serde(rename_all = "PascalCase")]
     Chest {
-        #[serde(rename = "Items")]
+        #[serde(default)]
         items: Vec<InventorySlot>,
         loot_table: Option<String>,
         loot_table_seed: Option<i64>,
     },
     #[serde(rename = "minecraft:comparator")]
+    #[serde(rename_all = "PascalCase")]
     Comparator { output_signal: i32 },
     #[serde(rename = "minecraft:command_block")]
+    #[serde(rename_all = "PascalCase")]
     CommandBlock {
         custom_name: Option<String>,
         command: String,
@@ -104,20 +115,28 @@ pub enum BlockEntityKind {
         last_execution: i64,
     },
     #[serde(rename = "minecraft:daylight_detector")]
+    #[serde(rename_all = "PascalCase")]
     DaylightDetector, // empty
     #[serde(rename = "minecraft:dispenser")]
+    #[serde(rename_all = "PascalCase")]
     Dispenser { items: Vec<InventorySlot> },
     #[serde(rename = "minecraft:dropper")]
+    #[serde(rename_all = "PascalCase")]
     Dropper { items: Vec<InventorySlot> },
     #[serde(rename = "minecraft:enchanting_table")]
+    #[serde(rename_all = "PascalCase")]
     EnchantingTable,
     #[serde(rename = "minecraft:ender_chest")]
+    #[serde(rename_all = "PascalCase")]
     EnderChest,
     #[serde(rename = "minecraft:end_gateway")]
+    #[serde(rename_all = "PascalCase")]
     EndGateway { age: i64, exact_teleport: bool },
     #[serde(rename = "minecraft:end_portal")]
+    #[serde(rename_all = "PascalCase")]
     EndPortal,
     #[serde(rename = "minecraft:furnace")]
+    #[serde(rename_all = "PascalCase")]
     Furnace {
         items: Vec<InventorySlot>,
         burn_time: i16,
@@ -125,11 +144,13 @@ pub enum BlockEntityKind {
         cook_time_total: i16,
     },
     #[serde(rename = "minecraft:hopper")]
+    #[serde(rename_all = "PascalCase")]
     Hopper {
         items: Vec<InventorySlot>,
         transfer_cooldown: i32,
     },
     #[serde(rename = "minecraft:jigsaw")]
+    #[serde(rename_all = "PascalCase")]
     Jigsaw {
         target_pool: String,
         final_state: String,
@@ -138,13 +159,20 @@ pub enum BlockEntityKind {
         attachment_type: String,
     },
     #[serde(rename = "minecraft:jukebox")]
+    #[serde(rename_all = "PascalCase")]
     Jukebox { record_item: InventorySlot },
+    #[serde(rename = "minecraft:mob_spawner")]
+    #[serde(rename_all = "PascalCase")]
+    MobSpawner {
+        // TODO
+    },
     // TODO: a few more
 }
 
 impl BlockEntityKind {
     pub fn variant(&self) -> BlockEntityVariant {
         match self {
+            BlockEntityKind::Banner { .. } => BlockEntityVariant::Banner,
             BlockEntityKind::Beacon { .. } => BlockEntityVariant::Beacon,
             BlockEntityKind::Bed { .. } => BlockEntityVariant::Bed,
             BlockEntityKind::BrewingStand { .. } => BlockEntityVariant::BrewingStand,
@@ -163,6 +191,7 @@ impl BlockEntityKind {
             BlockEntityKind::Hopper { .. } => BlockEntityVariant::Hopper,
             BlockEntityKind::Jigsaw { .. } => BlockEntityVariant::Jigsaw,
             BlockEntityKind::Jukebox { .. } => BlockEntityVariant::Jukebox,
+            BlockEntityKind::MobSpawner { .. } => BlockEntityVariant::MobSpawner,
         }
     }
 }
@@ -170,6 +199,7 @@ impl BlockEntityKind {
 /// Variant of a `BlockEntityKind`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BlockEntityVariant {
+    Banner,
     Beacon,
     Bed,
     BrewingStand,
@@ -188,4 +218,5 @@ pub enum BlockEntityVariant {
     Hopper,
     Jigsaw,
     Jukebox,
+    MobSpawner,
 }

--- a/core/anvil/src/entity.rs
+++ b/core/anvil/src/entity.rs
@@ -220,10 +220,7 @@ impl AnimalData {
 impl AnimalData {
     /// Creates a `BaseEntityData` from its parameters.
     pub fn new(base: BaseEntityData, health: f32) -> Self {
-        Self {
-            base,
-            health
-        }
+        Self { base, health }
     }
 }
 
@@ -288,10 +285,7 @@ impl ItemEntityData {
         map.insert(String::from("Item"), Value::Compound(item));
 
         map.insert(String::from("Age"), Value::Short(self.age));
-        map.insert(
-            String::from("PickupDelay"),
-            Value::Short(self.pickup_delay),
-        );
+        map.insert(String::from("PickupDelay"), Value::Short(self.pickup_delay));
         map.insert(String::from("Health"), Value::Short(self.health));
     }
 }

--- a/core/anvil/src/entity.rs
+++ b/core/anvil/src/entity.rs
@@ -218,7 +218,7 @@ impl AnimalData {
 }
 
 impl AnimalData {
-    /// Creates a `BaseEntityData` from its parameters.
+    /// Creates an `AnimalData` from its parameters.
     pub fn new(base: BaseEntityData, health: f32) -> Self {
         Self { base, health }
     }

--- a/core/anvil/src/player.rs
+++ b/core/anvil/src/player.rs
@@ -1,4 +1,4 @@
-use crate::entity::BaseEntityData;
+use crate::entity::AnimalData;
 use feather_inventory::player_constants::{
     HOTBAR_SIZE, INVENTORY_SIZE, SLOT_ARMOR_MAX, SLOT_ARMOR_MIN, SLOT_HOTBAR_OFFSET,
     SLOT_INVENTORY_OFFSET, SLOT_OFFHAND,
@@ -19,7 +19,7 @@ use uuid::Uuid;
 pub struct PlayerData {
     // Inherit base entity data
     #[serde(flatten)]
-    pub entity: BaseEntityData,
+    pub animal: AnimalData,
 
     #[serde(rename = "playerGameType")]
     pub gamemode: i32,

--- a/core/anvil/src/region/blob.rs
+++ b/core/anvil/src/region/blob.rs
@@ -94,23 +94,23 @@ fn heightmaps_to_value(heightmaps: Heightmaps) -> Value {
 
     map.insert(
         String::from("LIGHT_BLOCKING"),
-        Value::LongArray(Heightmaps::pack_u9(heightmaps.light_blocking)),
+        Value::LongArray(Heightmaps::pack_u9(&heightmaps.light_blocking)),
     );
     map.insert(
         String::from("MOTION_BLOCKING"),
-        Value::LongArray(Heightmaps::pack_u9(heightmaps.motion_blocking)),
+        Value::LongArray(Heightmaps::pack_u9(&heightmaps.motion_blocking)),
     );
     map.insert(
         String::from("MOTION_BLOCKING_NO_LEAVES"),
-        Value::LongArray(Heightmaps::pack_u9(heightmaps.motion_blocking_no_leaves)),
+        Value::LongArray(Heightmaps::pack_u9(&heightmaps.motion_blocking_no_leaves)),
     );
     map.insert(
         String::from("OCEAN_FLOOR"),
-        Value::LongArray(Heightmaps::pack_u9(heightmaps.ocean_floor)),
+        Value::LongArray(Heightmaps::pack_u9(&heightmaps.ocean_floor)),
     );
     map.insert(
         String::from("WORLD_SURFACE"),
-        Value::LongArray(Heightmaps::pack_u9(heightmaps.world_surface)),
+        Value::LongArray(Heightmaps::pack_u9(&heightmaps.world_surface)),
     );
 
     Value::Compound(map)

--- a/core/anvil/src/region/blob.rs
+++ b/core/anvil/src/region/blob.rs
@@ -94,25 +94,23 @@ fn heightmaps_to_value(heightmaps: Heightmaps) -> Value {
 
     map.insert(
         String::from("LIGHT_BLOCKING"),
-        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.light_blocking)),
+        Value::LongArray(Heightmaps::pack_u9(heightmaps.light_blocking)),
     );
     map.insert(
         String::from("MOTION_BLOCKING"),
-        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.motion_blocking)),
+        Value::LongArray(Heightmaps::pack_u9(heightmaps.motion_blocking)),
     );
     map.insert(
         String::from("MOTION_BLOCKING_NO_LEAVES"),
-        Value::LongArray(Heightmaps::packed_i64_vec(
-            heightmaps.motion_blocking_no_leaves,
-        )),
+        Value::LongArray(Heightmaps::pack_u9(heightmaps.motion_blocking_no_leaves)),
     );
     map.insert(
         String::from("OCEAN_FLOOR"),
-        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.ocean_floor)),
+        Value::LongArray(Heightmaps::pack_u9(heightmaps.ocean_floor)),
     );
     map.insert(
         String::from("WORLD_SURFACE"),
-        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.world_surface)),
+        Value::LongArray(Heightmaps::pack_u9(heightmaps.world_surface)),
     );
 
     Value::Compound(map)

--- a/core/anvil/src/region/blob.rs
+++ b/core/anvil/src/region/blob.rs
@@ -3,6 +3,7 @@
 
 use super::ChunkLevel;
 use super::{ChunkRoot, LevelSection};
+use crate::region::Heightmaps;
 use nbt::{Blob, Value};
 use std::collections::HashMap;
 
@@ -26,7 +27,7 @@ fn level_to_value(level: ChunkLevel) -> Value {
 
     map.insert(
         String::from("Heightmaps"),
-        Value::LongArray(level.heightmaps),
+        heightmaps_to_value(level.heightmaps),
     );
 
     let sections = level.sections.into_iter().map(section_to_value).collect();
@@ -88,6 +89,35 @@ fn level_to_value(level: ChunkLevel) -> Value {
     Value::Compound(map)
 }
 
+fn heightmaps_to_value(heightmaps: Heightmaps) -> Value {
+    let mut map = HashMap::new();
+
+    map.insert(
+        String::from("LIGHT_BLOCKING"),
+        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.light_blocking)),
+    );
+    map.insert(
+        String::from("MOTION_BLOCKING"),
+        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.motion_blocking)),
+    );
+    map.insert(
+        String::from("MOTION_BLOCKING_NO_LEAVES"),
+        Value::LongArray(Heightmaps::packed_i64_vec(
+            heightmaps.motion_blocking_no_leaves,
+        )),
+    );
+    map.insert(
+        String::from("OCEAN_FLOOR"),
+        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.ocean_floor)),
+    );
+    map.insert(
+        String::from("WORLD_SURFACE"),
+        Value::LongArray(Heightmaps::packed_i64_vec(heightmaps.world_surface)),
+    );
+
+    Value::Compound(map)
+}
+
 fn section_to_value(section: LevelSection) -> Value {
     let mut map = HashMap::new();
 
@@ -110,7 +140,7 @@ fn section_to_value(section: LevelSection) -> Value {
         let mut map = HashMap::new();
         map.insert(String::from("Name"), Value::String(entry.name.into_owned()));
 
-        if let Some(props) = entry.props {
+        if let Some(props) = entry.properties {
             let mut props_map = HashMap::new();
             props.props.into_iter().for_each(|(name, value)| {
                 props_map.insert(name, Value::String(value.into_owned()));
@@ -137,7 +167,7 @@ fn section_to_value(section: LevelSection) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::region::DATA_VERSION;
+    use crate::region::{Heightmaps, DATA_VERSION};
     use std::io::Cursor;
 
     #[test]
@@ -157,7 +187,13 @@ mod tests {
                 biomes: vec![10],
                 entities: vec![],
                 block_entities: vec![],
-                heightmaps: vec![],
+                heightmaps: Heightmaps {
+                    light_blocking: Box::new([0; 256]),
+                    motion_blocking: Box::new([0; 256]),
+                    motion_blocking_no_leaves: Box::new([0; 256]),
+                    ocean_floor: Box::new([0; 256]),
+                    world_surface: Box::new([0; 256]),
+                },
             },
         };
 

--- a/core/anvil/src/region/blob.rs
+++ b/core/anvil/src/region/blob.rs
@@ -188,11 +188,11 @@ mod tests {
                 entities: vec![],
                 block_entities: vec![],
                 heightmaps: Heightmaps {
-                    light_blocking: Box::new([0; 256]),
-                    motion_blocking: Box::new([0; 256]),
-                    motion_blocking_no_leaves: Box::new([0; 256]),
-                    ocean_floor: Box::new([0; 256]),
-                    world_surface: Box::new([0; 256]),
+                    light_blocking: vec![0; 256],
+                    motion_blocking: vec![0; 256],
+                    motion_blocking_no_leaves: vec![0; 256],
+                    ocean_floor: vec![0; 256],
+                    world_surface: vec![0; 256],
                 },
             },
         };

--- a/core/anvil/src/region/mod.rs
+++ b/core/anvil/src/region/mod.rs
@@ -1096,6 +1096,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::inconsistent-digit-grouping)] // Sorry clippy but grouping by 9 bits makes sense here
     fn test_packed_u9_order() {
         let data_u64 = [
             // this repeats every 9 u64...

--- a/core/anvil/src/region/mod.rs
+++ b/core/anvil/src/region/mod.rs
@@ -1089,7 +1089,7 @@ mod tests {
         tokenized_sequence.push(Token::StructEnd);
 
         let test_object = TestPackedU9 {
-            list: unpacked.clone(),
+            list: unpacked,
         };
 
         serde_test::assert_tokens(&test_object, tokenized_sequence.as_slice())
@@ -1142,7 +1142,7 @@ mod tests {
         tokenized_sequence.push(Token::StructEnd);
 
         let test_object = TestPackedU9 {
-            list: unpacked.clone(),
+            list: unpacked,
         };
 
         serde_test::assert_tokens(&test_object, tokenized_sequence.as_slice())

--- a/core/anvil/src/region/mod.rs
+++ b/core/anvil/src/region/mod.rs
@@ -1096,7 +1096,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::inconsistent-digit-grouping)] // Sorry clippy but grouping by 9 bits makes sense here
+    #[allow(clippy::inconsistent_digit_grouping)] // Sorry clippy but grouping by 9 bits makes sense here
     fn test_packed_u9_order() {
         let data_u64 = [
             // this repeats every 9 u64...

--- a/core/anvil/src/region/mod.rs
+++ b/core/anvil/src/region/mod.rs
@@ -1088,9 +1088,7 @@ mod tests {
         tokenized_sequence.push(Token::SeqEnd);
         tokenized_sequence.push(Token::StructEnd);
 
-        let test_object = TestPackedU9 {
-            list: unpacked,
-        };
+        let test_object = TestPackedU9 { list: unpacked };
 
         serde_test::assert_tokens(&test_object, tokenized_sequence.as_slice())
     }
@@ -1141,9 +1139,7 @@ mod tests {
         tokenized_sequence.push(Token::SeqEnd);
         tokenized_sequence.push(Token::StructEnd);
 
-        let test_object = TestPackedU9 {
-            list: unpacked,
-        };
+        let test_object = TestPackedU9 { list: unpacked };
 
         serde_test::assert_tokens(&test_object, tokenized_sequence.as_slice())
     }

--- a/core/chunk/src/lib.rs
+++ b/core/chunk/src/lib.rs
@@ -275,7 +275,7 @@ impl Chunk {
             &'static dyn Fn(&mut HeightMap, u16) -> (),
         );
 
-        let checks: Vec<HeightMapCheckContext> = vec![
+        let checks: [HeightMapCheckContext; 5] = [
             // Light blocking
             HeightMapCheckContext(
                 &|block| block.is_opaque(),
@@ -313,7 +313,8 @@ impl Chunk {
             ),
         ];
 
-        for HeightMapCheckContext(valid_block, check_mask, map_getter, map_setter) in checks {
+        for HeightMapCheckContext(valid_block, check_mask, map_getter, map_setter) in checks.iter()
+        {
             // Check heightmap type
             if valid_block(old_block) && map_getter(self.heightmap_mut(x, z)) == y {
                 // This was the highest block
@@ -327,12 +328,12 @@ impl Chunk {
                         break;
                     }
                 }
-                mask |= check_mask;
+                mask |= *check_mask;
             }
             if valid_block(new_block) && map_getter(self.heightmap_mut(x, z)) < y {
                 // This is the new highest block
                 map_setter(self.heightmap_mut(x, z), y);
-                mask |= check_mask;
+                mask |= *check_mask;
             }
         }
 

--- a/core/chunk/src/lib.rs
+++ b/core/chunk/src/lib.rs
@@ -68,70 +68,82 @@ pub struct Chunk {
 
 #[derive(Clone, Copy, Default)]
 pub struct HeightMap {
-    motion_blocking: u8,
-    motion_blocking_no_leaves: u8,
-    ocean_floor: u8,
-    ocean_floor_wg: u8,
-    world_surface: u8,
-    world_surface_wg: u8,
+    light_blocking: u16,
+    motion_blocking: u16,
+    motion_blocking_no_leaves: u16,
+    ocean_floor: u16,
+    world_surface: u16,
 }
 
 impl HeightMap {
-    /// The highest block that is solid or contains a fluid.
-    pub fn motion_blocking(self) -> u8 {
+    /// Y-coordinate + 1 of the highest opaque block.
+    pub fn light_blocking(self) -> u16 {
+        self.light_blocking
+    }
+
+    pub fn set_light_blocking(&mut self, mut light_blocking: u16) {
+        if light_blocking > 256 {
+            light_blocking = 256;
+        }
+        self.light_blocking = light_blocking;
+    }
+
+    /// Y-coordinate + 1 of the highest solid or fluid block.
+    pub fn motion_blocking(self) -> u16 {
         self.motion_blocking
     }
 
-    pub fn set_motion_blocking(&mut self, motion_blocking: u8) {
+    pub fn set_motion_blocking(&mut self, mut motion_blocking: u16) {
+        if motion_blocking > 256 {
+            motion_blocking = 256;
+        }
         self.motion_blocking = motion_blocking;
     }
 
-    /// The highest block that is solid or contains a fluid and is not leaves.
-    pub fn motion_blocking_no_leaves(self) -> u8 {
+    /// Y-coordinate + 1 of the highest solid or fluid block that is not leaves.
+    pub fn motion_blocking_no_leaves(self) -> u16 {
         self.motion_blocking_no_leaves
     }
 
-    pub fn set_motion_blocking_no_leaves(&mut self, motion_blocking_no_leaves: u8) {
+    pub fn set_motion_blocking_no_leaves(&mut self, mut motion_blocking_no_leaves: u16) {
+        if motion_blocking_no_leaves > 256 {
+            motion_blocking_no_leaves = 256;
+        }
         self.motion_blocking_no_leaves = motion_blocking_no_leaves;
     }
 
-    /// The highest block that is solid.
-    pub fn ocean_floor(self) -> u8 {
+    /// Y-coordinate + 1 of the highest solid block.
+    pub fn ocean_floor(self) -> u16 {
         self.ocean_floor
     }
 
-    pub fn set_ocean_floor(&mut self, ocean_floor: u8) {
+    pub fn set_ocean_floor(&mut self, mut ocean_floor: u16) {
+        if ocean_floor > 256 {
+            ocean_floor = 256;
+        }
         self.ocean_floor = ocean_floor;
     }
 
-    /// The highest block that is solid for world generation.
-    pub fn ocean_floor_wg(self) -> u8 {
-        self.ocean_floor_wg
-    }
-
-    /// The highest block that is not air.
-    pub fn world_surface(self) -> u8 {
+    /// Y-coordinate + 1 of the highest non-air block.
+    pub fn world_surface(self) -> u16 {
         self.world_surface
     }
 
-    pub fn set_world_surface(&mut self, world_surface: u8) {
+    pub fn set_world_surface(&mut self, mut world_surface: u16) {
+        if world_surface > 256 {
+            world_surface = 256;
+        }
         self.world_surface = world_surface;
-    }
-
-    /// The highest block is not air for world generation.
-    pub fn world_surface_wg(self) -> u8 {
-        self.world_surface_wg
     }
 }
 
 bitflags! {
     struct HeightMapMask: u8 {
-        const MOTION_BLOCKING = 0b0000_0001;
-        const MOTION_BLOCKING_NO_LEAVES = 0b0000_0010;
-        const OCEAN_FLOOR = 0b0000_0100;
-        const OCEAN_FLOOR_WG = 0b0000_1000;
+        const LIGHT_BLOCKING = 0b0000_0001;
+        const MOTION_BLOCKING = 0b0000_0010;
+        const MOTION_BLOCKING_NO_LEAVES = 0b0000_0100;
+        const OCEAN_FLOOR = 0b0000_1000;
         const WORLD_SURFACE = 0b0001_0000;
-        const WORLD_SURFACE_WG = 0b0010_0000;
     }
 }
 
@@ -225,9 +237,10 @@ impl Chunk {
             section = self.section_mut(y / 16).unwrap();
         }
 
+        let old_block = section.block_at(x, y % 16, z);
         section.set_block_at(x, y % 16, z, block);
 
-        self.update_heightmap(x, y, z, block);
+        self.update_heightmap(x, y, z, old_block, block);
     }
 
     pub fn heightmap(&self, x: usize, z: usize) -> &HeightMap {
@@ -244,31 +257,83 @@ impl Chunk {
         &self.heightmaps
     }
 
-    fn update_heightmap(&mut self, x: usize, y: usize, z: usize, block: BlockId) -> HeightMapMask {
-        let heightmap = self.heightmap_mut(x, z);
+    fn update_heightmap(
+        &mut self,
+        x: usize,
+        y: usize,
+        z: usize,
+        old_block: BlockId,
+        new_block: BlockId,
+    ) -> HeightMapMask {
         let mut mask: HeightMapMask = HeightMapMask::empty();
-        if (block.is_solid() || block.is_fluid()) && heightmap.motion_blocking() < y as u8 {
-            heightmap.set_motion_blocking(y as u8);
-            mask |= HeightMapMask::MOTION_BLOCKING;
+        let y = y as u16;
+
+        let checks: Vec<(
+            &dyn Fn(BlockId) -> bool,
+            HeightMapMask,
+            &dyn Fn(&HeightMap) -> u16,
+            &dyn Fn(&mut HeightMap, u16) -> (),
+        )> = vec![
+            // Light blocking
+            (
+                &|block| block.is_opaque(),
+                HeightMapMask::LIGHT_BLOCKING,
+                &|map| map.light_blocking(),
+                &|map, value| map.set_light_blocking(value),
+            ),
+            // Motion blocking
+            (
+                &|block| block.is_solid() || block.is_fluid(),
+                HeightMapMask::MOTION_BLOCKING,
+                &|map| map.motion_blocking(),
+                &|map, value| map.set_motion_blocking(value),
+            ),
+            // Motion blocking no leaves
+            (
+                &|block| (block.is_solid() || block.is_fluid()) && !block.is_leaves(),
+                HeightMapMask::MOTION_BLOCKING_NO_LEAVES,
+                &|map| map.motion_blocking_no_leaves(),
+                &|map, value| map.set_motion_blocking_no_leaves(value),
+            ),
+            // Ocean floor
+            (
+                &|block| block.is_solid(),
+                HeightMapMask::OCEAN_FLOOR,
+                &|map| map.ocean_floor(),
+                &|map, value| map.set_ocean_floor(value),
+            ),
+            // World surface
+            (
+                &|block| !block.is_air(),
+                HeightMapMask::WORLD_SURFACE,
+                &|map| map.world_surface(),
+                &|map, value| map.set_world_surface(value),
+            ),
+        ];
+
+        for (valid_block, check_mask, map_getter, map_setter) in checks {
+            // Check heightmap type
+            if valid_block(old_block) && map_getter(self.heightmap_mut(x, z)) == y {
+                // This was the highest block
+                self.heightmap_mut(x, z).set_light_blocking(0);
+
+                for i in (0..y).rev() {
+                    let block = self.block_at(x, i as usize, z);
+
+                    if valid_block(block) {
+                        map_setter(self.heightmap_mut(x, z), i + 1);
+                        break;
+                    }
+                }
+                mask |= check_mask;
+            }
+            if valid_block(new_block) && map_getter(self.heightmap_mut(x, z)) < y {
+                // This is the new highest block
+                map_setter(self.heightmap_mut(x, z), y);
+                mask |= check_mask;
+            }
         }
 
-        if (block.is_solid() || block.is_fluid())
-            && !block.is_leaves()
-            && heightmap.motion_blocking_no_leaves() < y as u8
-        {
-            heightmap.set_motion_blocking_no_leaves(y as u8);
-            mask |= HeightMapMask::MOTION_BLOCKING_NO_LEAVES;
-        }
-
-        if block.is_solid() && heightmap.ocean_floor() < y as u8 {
-            heightmap.set_ocean_floor(y as u8);
-            mask |= HeightMapMask::OCEAN_FLOOR;
-        }
-
-        if !block.is_air() && heightmap.world_surface() < y as u8 {
-            heightmap.set_world_surface(y as u8);
-            mask |= HeightMapMask::WORLD_SURFACE;
-        }
         mask
     }
 
@@ -284,7 +349,7 @@ impl Chunk {
                         break;
                     }
                     let block = self.block_at(x, y, z);
-                    mask |= self.update_heightmap(x, y, z, block);
+                    mask |= self.update_heightmap(x, y, z, BlockId::air(), block);
                 }
             }
         }

--- a/server/chunk/src/chunk_worker.rs
+++ b/server/chunk/src/chunk_worker.rs
@@ -233,6 +233,7 @@ fn save_chunk(worker: &mut ChunkWorker, save: ChunkSave) {
 
     let file = worker_region(&mut worker.open_regions, &worker.dir, rpos);
 
+    // TODO don't crash the server when a chunk fails to save
     file.handle
         .save_chunk(&*chunk, &save.entities, &save.block_entities)
         .unwrap();

--- a/server/chunk/src/save.rs
+++ b/server/chunk/src/save.rs
@@ -1,7 +1,7 @@
 //! Handles saving of chunks and entities
 
 use crate::{chunk_manager, ChunkWorkerHandle};
-use feather_core::anvil::entity::{BaseEntityData, EntityData};
+use feather_core::anvil::entity::{BaseEntityData, EntityData, AnimalData};
 use feather_core::anvil::{
     block_entity::BlockEntityData,
     player::{InventorySlot, PlayerData},
@@ -197,9 +197,11 @@ pub fn save_player_data(game: &Game, world: &World, player: Entity) {
         .map(|health| health.0 as f32)
         .unwrap_or(1.0);
     let data = PlayerData {
-        entity: BaseEntityData::new(
-            *world.get::<Position>(player),
-            Vec3d::broadcast(0.0),
+        animal: AnimalData::new(
+            BaseEntityData::new(
+                *world.get::<Position>(player),
+                Vec3d::broadcast(0.0),
+            ),
             health,
         ),
         gamemode: world.get::<Gamemode>(player).id() as i32,

--- a/server/chunk/src/save.rs
+++ b/server/chunk/src/save.rs
@@ -1,7 +1,7 @@
 //! Handles saving of chunks and entities
 
 use crate::{chunk_manager, ChunkWorkerHandle};
-use feather_core::anvil::entity::{BaseEntityData, EntityData, AnimalData};
+use feather_core::anvil::entity::{AnimalData, BaseEntityData, EntityData};
 use feather_core::anvil::{
     block_entity::BlockEntityData,
     player::{InventorySlot, PlayerData},
@@ -198,10 +198,7 @@ pub fn save_player_data(game: &Game, world: &World, player: Entity) {
         .unwrap_or(1.0);
     let data = PlayerData {
         animal: AnimalData::new(
-            BaseEntityData::new(
-                *world.get::<Position>(player),
-                Vec3d::broadcast(0.0),
-            ),
+            BaseEntityData::new(*world.get::<Position>(player), Vec3d::broadcast(0.0)),
             health,
         ),
         gamemode: world.get::<Gamemode>(player).id() as i32,

--- a/server/entity/src/object/arrow.rs
+++ b/server/entity/src/object/arrow.rs
@@ -51,10 +51,7 @@ fn serialize(_game: &Game, accessor: &EntityRef) -> EntityData {
     let vel = accessor.get::<Velocity>().0;
 
     EntityData::Arrow(ArrowEntityData {
-        entity: BaseEntityData::new(
-            *accessor.get::<Position>(),
-            Vec3d::new(vel.x, vel.y, vel.z),
-        ),
+        entity: BaseEntityData::new(*accessor.get::<Position>(), Vec3d::new(vel.x, vel.y, vel.z)),
         critical: 0, // TODO
     })
 }

--- a/server/entity/src/object/arrow.rs
+++ b/server/entity/src/object/arrow.rs
@@ -54,7 +54,6 @@ fn serialize(_game: &Game, accessor: &EntityRef) -> EntityData {
         entity: BaseEntityData::new(
             *accessor.get::<Position>(),
             Vec3d::new(vel.x, vel.y, vel.z),
-            1.0,
         ),
         critical: 0, // TODO
     })

--- a/server/entity/src/object/item.rs
+++ b/server/entity/src/object/item.rs
@@ -225,10 +225,7 @@ fn serialize(game: &Game, accessor: &EntityRef) -> EntityData {
     let vel = accessor.get::<Velocity>().0;
     let item = accessor.get::<ItemStack>();
     EntityData::Item(ItemEntityData {
-        entity: BaseEntityData::new(
-            *accessor.get::<Position>(),
-            Vec3d::new(vel.x, vel.y, vel.z),
-        ),
+        entity: BaseEntityData::new(*accessor.get::<Position>(), Vec3d::new(vel.x, vel.y, vel.z)),
         age: 0, // todo
         pickup_delay: (accessor.get::<CollectableAt>().0 as i64 - game.tick_count as i64).max(0)
             as i16,

--- a/server/entity/src/object/item.rs
+++ b/server/entity/src/object/item.rs
@@ -228,15 +228,15 @@ fn serialize(game: &Game, accessor: &EntityRef) -> EntityData {
         entity: BaseEntityData::new(
             *accessor.get::<Position>(),
             Vec3d::new(vel.x, vel.y, vel.z),
-            1.0,
         ),
         age: 0, // todo
         pickup_delay: (accessor.get::<CollectableAt>().0 as i64 - game.tick_count as i64).max(0)
-            as u8,
+            as i16,
         item: ItemData {
-            count: item.amount,
+            count: item.amount as i8,
             item: item.ty.identifier().to_owned(),
         },
+        health: 5, // todo
     })
 }
 
@@ -249,7 +249,7 @@ fn load(data: EntityData) -> anyhow::Result<EntityBuilder> {
             let stack = ItemStack::new(
                 Item::from_identifier(&data.item.item)
                     .ok_or_else(|| anyhow::anyhow!("invalid item {}", data.item.item))?,
-                data.item.count,
+                data.item.count as u8,
             );
 
             let collectable_at = data.pickup_delay;

--- a/server/network/src/worker.rs
+++ b/server/network/src/worker.rs
@@ -8,7 +8,7 @@
 
 use crate::initial_handler::{Action, InitialHandler};
 use crate::{ListenerToServerMessage, NewClientInfo, ServerToListenerMessage};
-use feather_core::anvil::entity::{BaseEntityData, AnimalData};
+use feather_core::anvil::entity::{AnimalData, BaseEntityData};
 use feather_core::anvil::player::PlayerData;
 use feather_core::network::{MinecraftCodec, Packet, PacketDirection};
 use feather_core::util::{Position, Vec3d};
@@ -237,7 +237,7 @@ async fn load_player_data(config: &Config, uuid: Uuid) -> Result<PlayerData, any
             let data = PlayerData {
                 animal: AnimalData::new(
                     BaseEntityData::new(DEFAULT_POSITION, Vec3d::broadcast(0.0)),
-                    20.0
+                    20.0,
                 ),
                 gamemode: config.server.default_gamemode.id() as i32,
                 inventory: vec![],

--- a/server/network/src/worker.rs
+++ b/server/network/src/worker.rs
@@ -8,7 +8,7 @@
 
 use crate::initial_handler::{Action, InitialHandler};
 use crate::{ListenerToServerMessage, NewClientInfo, ServerToListenerMessage};
-use feather_core::anvil::entity::BaseEntityData;
+use feather_core::anvil::entity::{BaseEntityData, AnimalData};
 use feather_core::anvil::player::PlayerData;
 use feather_core::network::{MinecraftCodec, Packet, PacketDirection};
 use feather_core::util::{Position, Vec3d};
@@ -195,7 +195,7 @@ async fn handle_ih_actions(worker: &mut Worker) -> anyhow::Result<()> {
             Action::SetStage(stage) => worker.framed.codec_mut().set_stage(stage),
             Action::JoinGame(info) => {
                 let data = load_player_data(&worker.config, info.uuid).await?;
-                let position = data.entity.read_position()?;
+                let position = data.animal.base.read_position()?;
                 let info = NewClientInfo {
                     ip: worker.ip,
                     username: info.username.unwrap_or_else(|| String::from("undefined")),
@@ -235,7 +235,10 @@ async fn load_player_data(config: &Config, uuid: Uuid) -> Result<PlayerData, any
             );
 
             let data = PlayerData {
-                entity: BaseEntityData::new(DEFAULT_POSITION, Vec3d::broadcast(0.0), 20.0),
+                animal: AnimalData::new(
+                    BaseEntityData::new(DEFAULT_POSITION, Vec3d::broadcast(0.0)),
+                    20.0
+                ),
                 gamemode: config.server.default_gamemode.id() as i32,
                 inventory: vec![],
             };

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -118,7 +118,7 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
     world.add(entity, CanRespawn).unwrap();
     world.add(entity, MaxHealth(20)).unwrap();
     world
-        .add(entity, Health(info.data.entity.health as u32))
+        .add(entity, Health(info.data.animal.health as u32))
         .unwrap();
     world.add(entity, BlocksFallen::default()).unwrap();
 
@@ -137,7 +137,7 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
         world,
         HealthUpdateEvent {
             old: 0,
-            new: info.data.entity.health as u32,
+            new: info.data.animal.health as u32,
             entity,
         },
     );

--- a/server/test/src/unit.rs
+++ b/server/test/src/unit.rs
@@ -1,6 +1,6 @@
 //! Unit testing framework.
 
-use feather_core::anvil::entity::{BaseEntityData, AnimalData};
+use feather_core::anvil::entity::{AnimalData, BaseEntityData};
 use feather_core::anvil::player::PlayerData;
 use feather_core::network::{cast_packet, Packet};
 use feather_core::{
@@ -200,10 +200,7 @@ impl Test {
             profile: vec![],
             uuid: Uuid::new_v4(),
             data: PlayerData {
-                animal: AnimalData::new(
-                    BaseEntityData::new(position, vec3(0.0, 0.0, 0.0)),
-                    20.0
-                ),
+                animal: AnimalData::new(BaseEntityData::new(position, vec3(0.0, 0.0, 0.0)), 20.0),
                 gamemode: 1,
                 inventory: vec![],
             },

--- a/server/test/src/unit.rs
+++ b/server/test/src/unit.rs
@@ -1,6 +1,6 @@
 //! Unit testing framework.
 
-use feather_core::anvil::entity::BaseEntityData;
+use feather_core::anvil::entity::{BaseEntityData, AnimalData};
 use feather_core::anvil::player::PlayerData;
 use feather_core::network::{cast_packet, Packet};
 use feather_core::{
@@ -200,7 +200,10 @@ impl Test {
             profile: vec![],
             uuid: Uuid::new_v4(),
             data: PlayerData {
-                entity: BaseEntityData::new(position, vec3(0.0, 0.0, 0.0), 20.0),
+                animal: AnimalData::new(
+                    BaseEntityData::new(position, vec3(0.0, 0.0, 0.0)),
+                    20.0
+                ),
                 gamemode: 1,
                 inventory: vec![],
             },


### PR DESCRIPTION
This PR aims to fix a few issues I encoutered when trying to load a vanilla world. Mainly this fixes the format of heightmaps in chunk data.
This is basically ready to merge, just needs a little polish. Namely:
- [X] Remove panics from `packed_u9`.
    (I just can't figure out how to return an error from `serialize` or `deserialize`. I thought `serde::ser::Error::custom("my error")` would do the trick but rustc says nope.)
- [X] Complete the test implementation for `packed_u9`/`Heightmaps::packed_i64_vec`.
- [X] Run `cargo fmt` and check `cargo clippy`.

Resolves #265.