### PR TITLE
Update TextArgument with fixed advance_to_end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,8 +1900,8 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "lieutenant"
-version = "0.1.0"
-source = "git+https://github.com/feather-rs/lieutenant#52a14a6e30bd3d6335d1883fcdc8d36cc89dbae0"
+version = "0.2.0"
+source = "git+https://github.com/feather-rs/lieutenant#c8f7a3fb02fe852dcd91de5d711e993610dda29a"
 dependencies = [
  "derivative 2.1.1",
  "lieutenant-macros",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "lieutenant-macros"
 version = "0.1.0"
-source = "git+https://github.com/feather-rs/lieutenant#52a14a6e30bd3d6335d1883fcdc8d36cc89dbae0"
+source = "git+https://github.com/feather-rs/lieutenant#c8f7a3fb02fe852dcd91de5d711e993610dda29a"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/server/commands/src/arguments.rs
+++ b/server/commands/src/arguments.rs
@@ -285,8 +285,7 @@ impl ArgumentKind<CommandCtx> for TextArgument {
     type ParseError = Infallible;
 
     fn satisfies<'a>(_ctx: &CommandCtx, input: &mut Input<'a>) -> bool {
-        // Required until #11 is fixed in https://github.com/feather-rs/lieutenant/issues/11
-        !input.advance_until("\0").is_empty()
+        !input.advance_to_end().is_empty()
     }
 
     fn parse<'a>(_ctx: &CommandCtx, input: &mut Input<'a>) -> Result<Self, Self::ParseError> {

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -107,6 +107,7 @@ impl CommandState {
 
                 whisper,
                 say,
+                me,
 
                 stop,
         }


### PR DESCRIPTION
This is a follow up MR related to feather-rs/lieutenant#13. As far as I am aware this is the only instance in the code base where `advance_to_end` should be used.

NOTE: I also added the `/me` command to the `commands` macro. For some reason this command was left out. Let me know if this should be done in a separate MR.