### PR TITLE
Fix entity duplication and add Velocity and PreviousVelocity to player

### DIFF
--- a/core/chunk/src/lib.rs
+++ b/core/chunk/src/lib.rs
@@ -526,6 +526,12 @@ impl Chunk {
         res
     }
 
+    /// Marks this chunk as modified.
+    /// See `check_modified`.
+    pub fn set_modified(&mut self) {
+        self.modified = true;
+    }
+
     fn biome_index(x: usize, z: usize) -> usize {
         assert!(x < 16);
         assert!(z < 16);

--- a/core/util/src/positions.rs
+++ b/core/util/src/positions.rs
@@ -177,8 +177,8 @@ impl From<glm::DVec3> for Position {
 impl From<Position> for ChunkPosition {
     fn from(pos: Position) -> Self {
         Self {
-            x: pos.x.floor() as i32 / 16,
-            z: pos.z.floor() as i32 / 16,
+            x: (pos.x / 16.0).floor() as i32,
+            z: (pos.z / 16.0).floor() as i32,
         }
     }
 }

--- a/server/chunk/src/save.rs
+++ b/server/chunk/src/save.rs
@@ -114,14 +114,15 @@ pub fn save_chunk_at(
     pos: ChunkPosition,
     chunk_worker_handle: &ChunkWorkerHandle,
 ) {
-    let chunk = game
+    // TODO fix this shortcut to save chunk with no entities in chunk when there were some previously
+    /*let chunk = game
         .chunk_map
         .chunk_handle_at(pos)
         .expect("chunk does not exist");
 
     if !chunk.write().check_modified() && game.chunk_entities.entities_in_chunk(pos).is_empty() {
         return;
-    }
+    }*/
 
     // Serialize the entities in the chunk.
     let (entities, block_entities) = serialize_entities(game, world, pos);

--- a/server/chunk/src/save.rs
+++ b/server/chunk/src/save.rs
@@ -114,15 +114,14 @@ pub fn save_chunk_at(
     pos: ChunkPosition,
     chunk_worker_handle: &ChunkWorkerHandle,
 ) {
-    // TODO fix this shortcut to save chunk with no entities in chunk when there were some previously
-    /*let chunk = game
+    let chunk = game
         .chunk_map
         .chunk_handle_at(pos)
         .expect("chunk does not exist");
 
     if !chunk.write().check_modified() && game.chunk_entities.entities_in_chunk(pos).is_empty() {
         return;
-    }*/
+    }
 
     // Serialize the entities in the chunk.
     let (entities, block_entities) = serialize_entities(game, world, pos);

--- a/server/entity/src/fall_damage.rs
+++ b/server/entity/src/fall_damage.rs
@@ -24,16 +24,16 @@ pub fn update_blocks_fallen(game: &mut Game, world: &mut World) {
         .for_each_entities_mut(
             world.inner_mut(),
             |(entity, (pos, prev_pos, mut blocks_fallen))| {
-                match (prev_pos.0.on_ground, pos.on_ground) {
-                    (false, false) => {
+                match (prev_pos.0.map(|pos| pos.on_ground), pos.on_ground) {
+                    (Some(false), false) => {
                         // In air: update blocks_fallen
-                        blocks_fallen.0 += (prev_pos.0.y - pos.y).max(0.0);
+                        blocks_fallen.0 += (prev_pos.0.unwrap().y - pos.y).max(0.0);
                     }
-                    (true, false) => {
+                    (Some(true), false) => {
                         // reset blocks_fallen
                         blocks_fallen.0 = 0.0;
                     }
-                    (false, true) => {
+                    (Some(false), true) => {
                         // landed
                         landed.borrow_mut().push(entity);
                     }

--- a/server/entity/src/lib.rs
+++ b/server/entity/src/lib.rs
@@ -38,13 +38,13 @@ pub fn previous_position_velocity_reset(world: &mut World) {
     <(Read<Position>, Write<PreviousPosition>)>::query().par_for_each_mut(
         world.inner_mut(),
         |(pos, mut previous_pos)| {
-            previous_pos.0 = *pos;
+            previous_pos.0.replace(*pos);
         },
     );
     <(Read<Velocity>, Write<PreviousVelocity>)>::query().par_for_each_mut(
         world.inner_mut(),
         |(vel, mut previous_vel)| {
-            previous_vel.0 = vel.0;
+            previous_vel.0.replace(vel.0);
         },
     );
 }
@@ -60,7 +60,7 @@ pub fn base() -> EntityBuilder {
         .with(NetworkId(id))
         .with(Velocity::default())
         .with(PreviousVelocity::default())
-        .with(PreviousPosition(position!(0.0, 0.0, 0.0)))
+        .with(PreviousPosition::default())
 }
 
 /// Returns a new entity ID.

--- a/server/entity/src/lib.rs
+++ b/server/entity/src/lib.rs
@@ -26,7 +26,9 @@ pub use object::*;
 extern crate nalgebra_glm as glm;
 
 use feather_core::util::Position;
-use feather_server_types::{NetworkId, PreviousPosition, PreviousVelocity, Velocity};
+use feather_server_types::{
+    ChunkCrossEvent, Game, NetworkId, PreviousPosition, PreviousVelocity, Velocity,
+};
 use fecs::{EntityBuilder, IntoQuery, Read, World, Write};
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -47,6 +49,15 @@ pub fn previous_position_velocity_reset(world: &mut World) {
             previous_vel.0.replace(vel.0);
         },
     );
+}
+
+#[fecs::event_handler]
+pub fn on_chunk_cross_mark_modified(event: &ChunkCrossEvent, game: &mut Game) {
+    if let Some(pos) = event.old {
+        if let Some(mut old_chunk) = game.chunk_map.chunk_at_mut(pos) {
+            old_chunk.set_modified()
+        }
+    }
 }
 
 /// Inserts the base components for an entity into an `EntityBuilder`.

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -21,7 +21,7 @@ use feather_server_types::{
     CreationPacketCreator, EntitySpawnEvent, Game, GamemodeUpdateEvent, Health, HealthUpdateEvent,
     HeldItem, InventoryUpdateEvent, LastKnownPositions, MaxHealth, MessageReceiver, Name, Network,
     NetworkId, OpenWindowCount, Player, PlayerJoinEvent, PlayerPreJoinEvent, PreviousPosition,
-    ProfileProperties, SpawnPacketCreator, Uuid,
+    PreviousVelocity, ProfileProperties, SpawnPacketCreator, Uuid, Velocity,
 };
 use feather_server_util::degrees_to_stops;
 use fecs::{Entity, EntityRef, World};
@@ -47,7 +47,9 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
     let entity = info.entity;
     world.add(entity, NetworkId(entity::new_id())).unwrap();
     world.add(entity, info.position).unwrap();
-    world.add(entity, PreviousPosition(info.position)).unwrap();
+    world.add(entity, PreviousPosition::default()).unwrap();
+    world.add(entity, Velocity::default()).unwrap();
+    world.add(entity, PreviousVelocity::default()).unwrap();
     world.add(entity, info.uuid).unwrap();
     world
         .add(

--- a/server/player/src/view.rs
+++ b/server/player/src/view.rs
@@ -43,8 +43,10 @@ pub fn check_crossed_chunks(world: &mut World, game: &mut Game) {
     for (entity, (pos, prev_pos)) in
         <(Read<Position>, Read<PreviousPosition>)>::query().iter_entities(world.inner())
     {
-        if pos.chunk() != prev_pos.0.chunk() {
-            crossed.push((entity, pos.chunk(), prev_pos.0.chunk()));
+        if let Some(prev_pos) = prev_pos.0 {
+            if pos.chunk() != prev_pos.chunk() {
+                crossed.push((entity, pos.chunk(), prev_pos.chunk()));
+            }
         }
     }
 

--- a/server/src/event_handlers.rs
+++ b/server/src/event_handlers.rs
@@ -59,6 +59,7 @@ pub fn build_event_handlers() -> EventHandlers {
 
         on_chunk_holder_release_unload_chunk,
 
+        on_chunk_cross_mark_modified,
         on_chunk_cross_update_chunks,
         on_chunk_cross_update_chunk_entities,
         on_chunk_cross_update_entities,

--- a/server/types/src/components.rs
+++ b/server/types/src/components.rs
@@ -29,8 +29,8 @@ pub struct HeldItem(pub usize);
 pub struct Name(pub String);
 
 /// Position of an entity on the previous tick.
-#[derive(Copy, Clone, Debug)]
-pub struct PreviousPosition(pub Position);
+#[derive(Copy, Clone, Debug, Default)]
+pub struct PreviousPosition(pub Option<Position>);
 
 /// An entity's velocity.
 #[derive(Copy, Clone, Debug)]
@@ -43,14 +43,8 @@ impl Default for Velocity {
 }
 
 /// Velocity of an entity on the previous tick.
-#[derive(Copy, Clone, Debug)]
-pub struct PreviousVelocity(pub glm::DVec3);
-
-impl Default for PreviousVelocity {
-    fn default() -> Self {
-        PreviousVelocity(Velocity::default().0)
-    }
-}
+#[derive(Copy, Clone, Debug, Default)]
+pub struct PreviousVelocity(pub Option<glm::DVec3>);
 
 /// Network ID of an entity.
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
This fixes #275 
I also added Velocity and PreviousVelocity components to player entities, I'm not sure whether they were intentionally left out but I couldn't find any evidence of them being added later so I took it as an oversight. Let me know whether I should revert that part.
Otherwise everything else should be explained in the issue.