### PR TITLE
Support non-x86 target compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "simdeez"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cc1807d0c7d2e869716572655b1abd32649b5600c047023f10c605bea8310f"
+checksum = "1893a4b8db694e23889b63229b6e1deb33846ee0552588bb6e45e53eff59667d"
 dependencies = [
  "cfg-if",
  "paste",
@@ -3026,9 +3026,8 @@ dependencies = [
 
 [[package]]
 name = "simdnoise"
-version = "3.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a31457560eda25097f625438e6583e853580ad201f4cf87c5a57e8aba118ca8"
+version = "3.1.6"
+source = "git+https://github.com/jackmott/rust-simd-noise?rev=6349670#6349670ebf3ea2bf7bca6695d33388bad2e197d9"
 dependencies = [
  "simdeez",
 ]

--- a/server/worldgen/Cargo.toml
+++ b/server/worldgen/Cargo.toml
@@ -12,7 +12,7 @@ smallvec = "1.4"
 rand = "0.7"
 rand_xorshift = "0.2"
 num-traits = "0.2"
-simdnoise = "3.1"
+simdnoise = { git = "https://github.com/jackmott/rust-simd-noise", rev = "6349670" } # needed for https://github.com/jackmott/rust-simd-noise/pull/31
 log = "0.4"
 once_cell = "1.3"
 strum = "0.18"

--- a/server/worldgen/src/noise.rs
+++ b/server/worldgen/src/noise.rs
@@ -73,13 +73,17 @@ impl<'a> NoiseLerper<'a> {
         // default to a scalar impl.
         // TODO: support SSE41, other SIMD instruction sets
 
-        if is_x86_feature_detected!("avx2") {
-            self.generate_avx2()
-        } else {
-            self.generate_fallback()
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("avx2") {
+                return self.generate_avx2();
+            }
         }
+
+        self.generate_fallback()
     }
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn generate_avx2(&self) -> Vec<f32> {
         // TODO: implement this. (Premature optimization is bad!)
         self.generate_fallback()


### PR DESCRIPTION
This PR implements a target-guard (`#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]`) in `feather-server-worldgen`'s noise.rs to only compile avx-related code on x86 targets.
~~For full non-x86 compilation support https://github.com/jackmott/rust-simd-noise/pull/31 has to be accepted to make the `simdnoise` dependency in `feather-server-worldgen` compile on non-x86 targets.~~
Edit: This PR was accepted way faster than expected, so feather should now successfully compile for non-x86 targets without any modifications to the source.