### PR TITLE
Implement basics of Tags and HeldItemChangeClientbound packets

### DIFF
--- a/core/anvil/src/player.rs
+++ b/core/anvil/src/player.rs
@@ -25,6 +25,8 @@ pub struct PlayerData {
     pub gamemode: i32,
     #[serde(rename = "Inventory")]
     pub inventory: Vec<InventorySlot>,
+    #[serde(rename = "SelectedItemSlot")]
+    pub held_item: i32,
 }
 
 /// Represents a single inventory slot (including position index).

--- a/core/blocks/src/lib.rs
+++ b/core/blocks/src/lib.rs
@@ -76,6 +76,24 @@ impl BlockId {
         VANILLA_ID_TABLE[self.kind as u16 as usize][self.state as usize]
     }
 
+    /// Returns the vanilla fluid ID for this block in case it is a fluid.
+    /// The fluid ID is used in the Tags packet.
+    pub fn vanilla_fluid_id(self) -> Option<u16> {
+        if self.is_fluid() {
+            match (self.kind(), self.water_level().unwrap()) {
+                // could be swapped?
+                (BlockKind::Water, 0) => Some(2), // stationary water
+                (BlockKind::Water, _) => Some(1), // flowing water
+                // tested those
+                (BlockKind::Lava, 0) => Some(4), // stationary lava
+                (BlockKind::Lava, _) => Some(3), // flowing lava
+                _ => unreachable!(),
+            }
+        } else {
+            None
+        }
+    }
+
     /// Returns the block corresponding to the given vanilla ID.
     ///
     /// (Invalid IDs currently return `BlockId::air()`).

--- a/core/network/src/packet.rs
+++ b/core/network/src/packet.rs
@@ -608,6 +608,11 @@ static PACKET_ID_MAPPINGS: Lazy<AHashMap<PacketId, PacketType>> = Lazy::new(|| {
     );
 
     m.insert(
+        PacketId(0x3D, PacketDirection::Clientbound, PacketStage::Play),
+        PacketType::HeldItemChangeClientbound,
+    );
+
+    m.insert(
         PacketId(0x3F, PacketDirection::Clientbound, PacketStage::Play),
         PacketType::EntityMetadata,
     );
@@ -645,6 +650,11 @@ static PACKET_ID_MAPPINGS: Lazy<AHashMap<PacketId, PacketType>> = Lazy::new(|| {
     m.insert(
         PacketId(0x50, PacketDirection::Clientbound, PacketStage::Play),
         PacketType::EntityTeleport,
+    );
+
+    m.insert(
+        PacketId(0x55, PacketDirection::Clientbound, PacketStage::Play),
+        PacketType::Tags,
     );
 
     m

--- a/core/network/src/packets.rs
+++ b/core/network/src/packets.rs
@@ -2423,29 +2423,8 @@ pub struct Tags {
 }
 
 impl Packet for Tags {
-    fn read_from(&mut self, buf: &mut Cursor<&[u8]>) -> anyhow::Result<()> {
-        for field in [
-            &mut self.block_tags,
-            &mut self.item_tags,
-            &mut self.fluid_tags,
-        ]
-        .iter_mut()
-        {
-            let length = buf.try_get_var_int()?;
-            for _tag in 0..length {
-                let identifier = buf.try_get_string()?;
-                let inner_length = buf.try_get_var_int()?;
-
-                let mut entries = Vec::with_capacity(inner_length as usize);
-                for _entry in 0..inner_length {
-                    entries.push(buf.try_get_var_int()?);
-                }
-
-                field.push((identifier, entries));
-            }
-        }
-
-        Ok(())
+    fn read_from(&mut self, _buf: &mut Cursor<&[u8]>) -> anyhow::Result<()> {
+        unimplemented!()
     }
 
     fn write_to(&self, buf: &mut BytesMut) {

--- a/server/chunk/src/save.rs
+++ b/server/chunk/src/save.rs
@@ -10,7 +10,7 @@ use feather_core::inventory::{Inventory, Window};
 use feather_core::util::{ChunkPosition, Gamemode, Position, Vec3d};
 use feather_server_types::{
     tasks, BlockSerializer, ChunkLoadEvent, ChunkUnloadEvent, ComponentSerializer, Game, Health,
-    PlayerLeaveEvent, Uuid, TICK_LENGTH, TPS,
+    HeldItem, PlayerLeaveEvent, Uuid, TICK_LENGTH, TPS,
 };
 use fecs::{Entity, World};
 use std::collections::VecDeque;
@@ -203,6 +203,7 @@ pub fn save_player_data(game: &Game, world: &World, player: Entity) {
         ),
         gamemode: world.get::<Gamemode>(player).id() as i32,
         inventory,
+        held_item: world.get::<HeldItem>(player).0 as i32,
     };
 
     let uuid = *world.get::<Uuid>(player);

--- a/server/network/src/worker.rs
+++ b/server/network/src/worker.rs
@@ -241,6 +241,7 @@ async fn load_player_data(config: &Config, uuid: Uuid) -> Result<PlayerData, any
                 ),
                 gamemode: config.server.default_gamemode.id() as i32,
                 inventory: vec![],
+                held_item: 0,
             };
 
             feather_core::anvil::player::save_player_data(

--- a/server/player/src/lib.rs
+++ b/server/player/src/lib.rs
@@ -109,7 +109,9 @@ pub fn create(game: &mut Game, world: &mut World, info: NewClientInfo) -> Entity
         (window, slots)
     };
     world.add(entity, window).unwrap();
-    world.add(entity, HeldItem(0)).unwrap(); // todo: load from player data
+    world
+        .add(entity, HeldItem(info.data.held_item as usize))
+        .unwrap();
 
     world.add(entity, MessageReceiver::default()).unwrap();
 

--- a/server/src/event_handlers.rs
+++ b/server/src/event_handlers.rs
@@ -44,7 +44,7 @@ pub fn build_event_handlers() -> EventHandlers {
 
         on_entity_client_remove_update_last_known_positions,
 
-        on_player_join_send_join_game,
+        on_player_join_send_join_packets,
         on_player_join_send_existing_entities,
         on_player_join_send_time,
         on_player_join_trigger_chunk_cross,

--- a/server/test/src/unit.rs
+++ b/server/test/src/unit.rs
@@ -203,6 +203,7 @@ impl Test {
                 animal: AnimalData::new(BaseEntityData::new(position, vec3(0.0, 0.0, 0.0)), 20.0),
                 gamemode: 1,
                 inventory: vec![],
+                held_item: 0,
             },
             position,
             sender: server_tx,


### PR DESCRIPTION
This PR aims to implement the basics of the Tags packet - right now primarily used to make sure lava is rendered correctly in the client - and the HeldItemChangeClientbound packet - sent at server join to set the players selected hotbar slot to the one they had selected on their last login.
Tags are a new feature of 1.13 that specify common traits of block types/item types/fluid types and could be sourced from the vanilla Data Generators. For now I only hardcoded the fluid tags for lava and water to fix the vanilla client rendering lava with a water texture without a tags packet and instead intend to wait on a decision in #267 for a full-fledged implementation of tags.
