### PR TITLE
Fix empty favicon being sent to server ping

### DIFF
--- a/server/network/src/initial_handler.rs
+++ b/server/network/src/initial_handler.rs
@@ -319,7 +319,7 @@ fn handle_request(ih: &mut InitialHandler, packet: &Request) -> Result<(), Error
     let server_icon = (*ih.server_icon).clone().unwrap_or_default();
 
     // Send response packet
-    let json = serde_json::json!({
+    let mut json = serde_json::json!({
         "version": {
             "name": SERVER_VERSION,
             "protocol": PROTOCOL_VERSION,
@@ -333,6 +333,11 @@ fn handle_request(ih: &mut InitialHandler, packet: &Request) -> Result<(), Error
         },
         "favicon": server_icon,
     });
+
+    // Remove the favicon field if there is no favicon
+    if server_icon.is_empty() {
+        json.as_object_mut().unwrap().remove("favicon");
+    }
 
     let response = Response {
         json_response: json.to_string(),


### PR DESCRIPTION
The favicon field should not be returned when responding to the clients ping.

Fixes #274

Testing:
Message from vanilla client output before change:
![image](https://user-images.githubusercontent.com/3639154/88246229-e42be080-cc67-11ea-965d-15288542f6f6.png)

Message from vanilla client output after change:
![image](https://user-images.githubusercontent.com/3639154/88246245-ec841b80-cc67-11ea-8eaf-4053db19a918.png)

Also tested with a valid server-icon.png and verified that it still appears with this change.