### PR TITLE
Set -C debuginfo=0 in CI for smaller cache sizes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,23 +22,23 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-registry3-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-registry2-
+          ${{ runner.os }}-cargo-registry3-
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-index3-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-index2-
+          ${{ runner.os }}-cargo-index3-
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target3-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-build-target2-
+          ${{ runner.os }}-cargo-build-target3-
 
     - name: Install rustfmt
       run: rustup component add rustfmt
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       run: cargo test
       env:
-        RUSTFLAGS: "-C opt-level=0"
+        RUSTFLAGS: "-C opt-level=0 debuginfo=0"
 
     - name: Install Clippy
       run: rustup component add clippy
@@ -54,7 +54,7 @@ jobs:
     - name: Run Clippy
       run: cargo clippy --all-targets -- -D warnings
       env:
-        RUSTFLAGS: "-C opt-level=0"
+        RUSTFLAGS: "-C opt-level=0 debuginfo=0"
     
     - name: Check formatting
       run: cargo fmt -- --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Run tests
       run: cargo test
       env:
-        RUSTFLAGS: "-C opt-level=0 debuginfo=0"
+        RUSTFLAGS: "-C opt-level=0 -C debuginfo=0"
 
     - name: Install Clippy
       run: rustup component add clippy
@@ -54,7 +54,7 @@ jobs:
     - name: Run Clippy
       run: cargo clippy --all-targets -- -D warnings
       env:
-        RUSTFLAGS: "-C opt-level=0 debuginfo=0"
+        RUSTFLAGS: "-C opt-level=0 -C debuginfo=0"
     
     - name: Check formatting
       run: cargo fmt -- --check


### PR DESCRIPTION
CI has been failing spuriously lately, caused by 500 errors in the caching pipeline.
I'm wondering if this is caused by the size of our target directory exceeding a limit
somewhere.