### PR TITLE
Implement seed command

### DIFF
--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -559,3 +559,11 @@ fn clear_items(
         );
     }
 }
+
+#[command(usage = "seed")]
+pub fn seed(ctx: &mut CommandCtx) -> anyhow::Result<()> {
+    Ok(Some(format!(
+        "Seed: [{}]",
+        ctx.game.level.seed.to_string()
+    )))
+}

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -11,7 +11,7 @@ use feather_core::util::{Gamemode, Position};
 use feather_definitions::Item;
 use feather_server_types::{
     ChatEvent, ChatPosition, GamemodeUpdateEvent, InventoryUpdateEvent, MessageReceiver, Name,
-    Player, ShutdownChannels, Teleported,
+    Network, Player, ShutdownChannels, Teleported,
 };
 use fecs::{Entity, ResourcesProvider, World};
 use lieutenant::command;
@@ -562,5 +562,14 @@ fn clear_items(
 
 #[command(usage = "seed")]
 pub fn seed(ctx: &mut CommandCtx) -> anyhow::Result<()> {
-    Ok(Some(format!("Seed: [{}]", ctx.game.level.seed.to_string())))
+    if let Some(mut message_receiver) = ctx.world.try_get_mut::<MessageReceiver>(ctx.sender) {
+        message_receiver.send(
+            Text::from("Seed: [")
+                + Text::from(ctx.game.level.seed.to_string())
+                    .green()
+                    .insertion(ctx.game.level.seed.to_string())
+                + Text::from("]"),
+        );
+    }
+    Ok(None)
 }

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -562,8 +562,5 @@ fn clear_items(
 
 #[command(usage = "seed")]
 pub fn seed(ctx: &mut CommandCtx) -> anyhow::Result<()> {
-    Ok(Some(format!(
-        "Seed: [{}]",
-        ctx.game.level.seed.to_string()
-    )))
+    Ok(Some(format!("Seed: [{}]", ctx.game.level.seed.to_string())))
 }

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -118,6 +118,7 @@ impl CommandState {
                 clear_2,
                 clear_3,
                 clear_4,
+                
                 seed,
         }
 

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -118,7 +118,7 @@ impl CommandState {
                 clear_2,
                 clear_3,
                 clear_4,
-                
+
                 seed,
         }
 

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -118,6 +118,7 @@ impl CommandState {
                 clear_2,
                 clear_3,
                 clear_4,
+                seed,
         }
 
         Self {


### PR DESCRIPTION
Implements /seed command for #229 
Currently command's output isn't colored nor clickable as it is in vanilla. 