### PR TITLE
Add middle click handler

### DIFF
--- a/server/player/src/packet_handlers/inventory.rs
+++ b/server/player/src/packet_handlers/inventory.rs
@@ -596,14 +596,8 @@ fn handle_middle_click(
 
         // Pick the item in the slot
         let picked = accessor.item_at(packet.slot as usize)?;
-        let count = picked.map(|item| item.ty.stack_size());
-        if count.is_none() {
-            drop(accessor);
-            drop(window);
-            return Ok(());
-        }
-        let count = count.unwrap();
         if let Some(item) = picked {
+            let count = item.ty.stack_size();
             drop(accessor);
             drop(window);
             world

--- a/server/player/src/packet_handlers/inventory.rs
+++ b/server/player/src/packet_handlers/inventory.rs
@@ -583,7 +583,7 @@ fn handle_middle_click(
     _game: &mut Game,
     world: &mut World,
     player: Entity,
-    packet: ClickWindow
+    packet: ClickWindow,
 ) -> anyhow::Result<()> {
     let gamemode = *world.get::<Gamemode>(player);
     if Gamemode::Creative == gamemode {

--- a/server/player/src/packet_handlers/inventory.rs
+++ b/server/player/src/packet_handlers/inventory.rs
@@ -582,7 +582,7 @@ fn handle_middle_click(
 ) -> anyhow::Result<()> {
     let gamemode = *world.get::<Gamemode>(player);
     if Gamemode::Creative == gamemode {
-        if let Some(_) = world.try_get::<PickedItem>(player) {
+        if world.try_get::<PickedItem>(player).is_some() {
             // Player already has something in its hand.
             return Ok(());
         }

--- a/server/player/src/packet_handlers/inventory.rs
+++ b/server/player/src/packet_handlers/inventory.rs
@@ -597,7 +597,7 @@ fn handle_middle_click(
         // Pick the item in the slot
         let picked = accessor.item_at(packet.slot as usize)?;
         let count = picked.map(|item| item.ty.stack_size());
-        if !count.is_some() {
+        if count.is_none() {
             drop(accessor);
             drop(window);
             return Ok(());


### PR DESCRIPTION
If the player is in creative gamemode + has nothing in hand (PickedItem = None), then make a stack out of whatever he clicked.

Sometimes clicking doesn't work but it's because long click (of any
kind) are considered painting by the client and so by the server and it is not yet implemented.

Let me know if it needs a rework.