### PR TITLE
IP & UUID Ban support + Associated Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 
 world/
 feather.toml
-
+bans.toml

--- a/server/commands/Cargo.toml
+++ b/server/commands/Cargo.toml
@@ -17,3 +17,5 @@ anyhow = "1.0"
 thiserror = "1.0"
 rand = "0.7"
 vek = "0.10"
+uuid = { version = "0.8", features = ["v3"] }
+tokio = { version = "0.2", features = ["full"] }

--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -10,13 +10,18 @@ use feather_core::text::{Text, TextComponentBuilder, TextValue};
 use feather_core::util::{Gamemode, Position};
 use feather_definitions::Item;
 use feather_server_types::{
-    ChatEvent, ChatPosition, GamemodeUpdateEvent, InventoryUpdateEvent, MessageReceiver, Name,
-    Player, ShutdownChannels, Teleported,
+    Ban, ChatEvent, ChatPosition, GamemodeUpdateEvent, InventoryUpdateEvent, MessageReceiver, Name,
+    Player, ShutdownChannels, Teleported, WrappedBanInfo,
 };
-use fecs::{Entity, ResourcesProvider, World};
+use feather_server_util::{name_to_uuid_offline, name_to_uuid_online};
+use fecs::{Entity, IntoQuery, Read, ResourcesProvider, World};
 use lieutenant::command;
 use smallvec::SmallVec;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
 use thiserror::Error;
+use tokio::runtime::Runtime;
+use uuid::Uuid;
 
 #[derive(Debug, Error)]
 pub enum TpError {
@@ -571,5 +576,243 @@ pub fn seed(ctx: &mut CommandCtx) -> anyhow::Result<()> {
                 + Text::from("]"),
         );
     }
+    Ok(None)
+}
+
+#[derive(Debug, Error)]
+pub enum BanError {
+    #[error(
+        "Only players may be affected by this command, but the provided selector includes entities"
+    )]
+    NotPlayer,
+    #[error("Already banned")]
+    NoTargets,
+}
+
+#[command(usage = "ban <targets> <reason>")]
+pub fn ban_withreason(
+    ctx: &mut CommandCtx,
+    targets: EntitySelector,
+    reason: TextArgument,
+) -> anyhow::Result<()> {
+    ban_players(ctx, targets, reason.0, false)
+}
+
+#[command(usage = "ban <targets>")]
+pub fn ban_noreason(ctx: &mut CommandCtx, targets: EntitySelector) -> anyhow::Result<()> {
+    ban_players(ctx, targets, "Banned by an operator.".to_owned(), false)
+}
+
+#[command(usage = "ban-ip <targets> <reason>")]
+pub fn banip_withreason(
+    ctx: &mut CommandCtx,
+    targets: EntitySelector,
+    reason: TextArgument,
+) -> anyhow::Result<()> {
+    ban_players(ctx, targets, reason.0, true)
+}
+
+#[command(usage = "ban-ip <targets>")]
+pub fn banip_noreason(ctx: &mut CommandCtx, targets: EntitySelector) -> anyhow::Result<()> {
+    ban_players(ctx, targets, "Banned by an operator.".to_owned(), true)
+}
+
+#[derive(Debug, Error)]
+pub enum BanIpError {
+    #[error("Not a valid IP Address.")]
+    InvalidIp,
+}
+
+#[command(usage = "ban-ip <ip> <reason>")]
+pub fn banip_withreason_ip(
+    ctx: &mut CommandCtx,
+    ip: String,
+    reason: TextArgument,
+) -> anyhow::Result<()> {
+    ban_ip(ctx, ip, reason.0)
+}
+
+#[command(usage = "ban-ip <ip>")]
+pub fn banip_noreason_ip(ctx: &mut CommandCtx, ip: String) -> anyhow::Result<()> {
+    ban_ip(ctx, ip, "IP Banned by an operator.".to_string())
+}
+
+pub fn ban_ip(ctx: &mut CommandCtx, ip: String, reason: String) -> anyhow::Result<Option<String>> {
+    let ip = IpAddr::from_str(&ip).map_err(|_| BanIpError::InvalidIp)?;
+
+    {
+        let bi_lock = ctx.game.resources.get::<WrappedBanInfo>();
+        let mut ban_info = bi_lock.write().unwrap();
+
+        ban_info.ip_bans.insert(
+            ip,
+            Ban {
+                reason: reason.clone(),
+                expires_after: None,
+            },
+        );
+    }
+
+    if let Some(mut sender_message_receiver) = ctx.world.try_get_mut::<MessageReceiver>(ctx.sender)
+    {
+        let ban_confirm = Text::from(TextValue::translate_with(
+            "commands.ban.success",
+            vec![Text::from(ip.to_string()), Text::from(reason.clone())],
+        ));
+        sender_message_receiver.send(ban_confirm);
+    }
+
+    let ent = Read::<(SocketAddr, Entity)>::query()
+        .iter(ctx.world.inner())
+        .find(|x| x.0.ip() == ip)
+        .map(|x| (*x).1);
+
+    if let Some(ent) = ent {
+        ctx.game.disconnect_and_log(
+            ent,
+            &mut ctx.world,
+            &Text::from(reason),
+            "Banned by an operator.",
+        );
+    }
+
+    Ok(None)
+}
+
+pub fn ban_players(
+    ctx: &mut CommandCtx,
+    targets: EntitySelector,
+    reason: String,
+    by_ip: bool,
+) -> anyhow::Result<Option<String>> {
+    if targets.entities.is_empty() {
+        return Err(BanError::NoTargets.into());
+    }
+
+    for entity in &targets.entities {
+        if ctx.world.try_get::<Player>(*entity).is_none() {
+            return Err(BanError::NotPlayer.into());
+        }
+    }
+
+    for entity in &targets.entities {
+        {
+            let bi_lock = ctx.game.resources.get::<WrappedBanInfo>();
+            let mut ban_info = bi_lock.write().unwrap();
+
+            if by_ip {
+                let ip = ctx.world.try_get::<SocketAddr>(*entity).unwrap();
+
+                ban_info.ip_bans.insert(
+                    ip.ip(),
+                    Ban {
+                        reason: reason.clone(),
+                        expires_after: None,
+                    },
+                );
+            } else {
+                let uuid = ctx.world.try_get::<Uuid>(*entity).unwrap();
+
+                ban_info.uuid_bans.insert(
+                    uuid.to_hyphenated_ref().to_string(),
+                    Ban {
+                        reason: reason.clone(),
+                        expires_after: None,
+                    },
+                );
+            }
+        }
+
+        let name = ctx.world.try_get::<Name>(*entity).unwrap().0.clone();
+        if let Some(mut sender_message_receiver) =
+            ctx.world.try_get_mut::<MessageReceiver>(ctx.sender)
+        {
+            let ban_confirm = Text::from(TextValue::translate_with(
+                "commands.ban.success",
+                vec![Text::from(name), Text::from(reason.clone())],
+            ));
+            sender_message_receiver.send(ban_confirm);
+        }
+
+        ctx.game.disconnect_and_log(
+            *entity,
+            &mut ctx.world,
+            &Text::from(reason.clone()),
+            "Banned by an operator.",
+        );
+    }
+
+    Ok(None)
+}
+
+#[derive(Debug, Error)]
+pub enum PardonError {
+    #[error("Couldn't find that players UUID, Have they changed name?")]
+    NotPlayer,
+}
+
+#[command(usage = "pardon <name>")]
+pub fn pardon(ctx: &mut CommandCtx, name: TextArgument) -> anyhow::Result<()> {
+    // Get UUID from name
+    let online_mode = ctx.game.shared.config.server.online_mode;
+    let uuid = if online_mode {
+        Runtime::new()
+            .unwrap()
+            .block_on(name_to_uuid_online(&name.0))
+    } else {
+        Some(name_to_uuid_offline(&name.0))
+    };
+
+    let uuid = match uuid {
+        Some(uuid) => uuid,
+        None => return Err(PardonError::NotPlayer.into()),
+    };
+
+    {
+        let bi_lock = ctx.game.resources.get::<WrappedBanInfo>();
+        let mut ban_info = bi_lock.write().unwrap();
+        ban_info
+            .uuid_bans
+            .remove(&uuid.to_hyphenated_ref().to_string());
+    }
+
+    if let Some(mut sender_message_receiver) = ctx.world.try_get_mut::<MessageReceiver>(ctx.sender)
+    {
+        let kick_confirm = Text::from(TextValue::translate_with(
+            "commands.pardon.success",
+            vec![Text::from(name.0)],
+        ));
+        sender_message_receiver.send(kick_confirm);
+    }
+
+    Ok(None)
+}
+
+#[derive(Debug, Error)]
+pub enum PardonIpError {
+    #[error("Invalid IP Address")]
+    NotIp,
+}
+
+#[command(usage = "pardon-ip <ip>")]
+pub fn pardonip(ctx: &mut CommandCtx, ip: String) -> anyhow::Result<()> {
+    // Try to parse ip
+    let addr = IpAddr::from_str(&ip).map_err(|_| PardonIpError::NotIp)?;
+
+    {
+        let bi_lock = ctx.game.resources.get::<WrappedBanInfo>();
+        let mut ban_info = bi_lock.write().unwrap();
+        ban_info.ip_bans.remove(&addr);
+    }
+
+    if let Some(mut sender_message_receiver) = ctx.world.try_get_mut::<MessageReceiver>(ctx.sender)
+    {
+        let kick_confirm = Text::from(TextValue::translate_with(
+            "commands.pardon.success",
+            vec![Text::from(ip)],
+        ));
+        sender_message_receiver.send(kick_confirm);
+    }
+
     Ok(None)
 }

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -120,6 +120,16 @@ impl CommandState {
                 clear_4,
 
                 seed,
+
+                ban_withreason,
+                ban_noreason,
+                banip_withreason,
+                banip_noreason,
+                banip_withreason_ip,
+                banip_noreason_ip,
+
+                pardon,
+                pardonip,
         }
 
         Self {

--- a/server/network/Cargo.toml
+++ b/server/network/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 feather-core = { path = "../../core" }
 feather-server-types = { path = "../types" }
+feather-server-util = { path = "../util" }
 
 fecs = { git = "https://github.com/feather-rs/fecs", rev = "0c4838d65b41ca059012b6e9147eabf0c275a731" }
 tokio = { version = "0.2", features = ["full"] }

--- a/server/network/src/lib.rs
+++ b/server/network/src/lib.rs
@@ -14,7 +14,7 @@ use derivative::Derivative;
 use feather_core::anvil::player::PlayerData;
 use feather_core::util::Position;
 use feather_server_types::{
-    Config, PacketBuffers, ServerToWorkerMessage, Uuid, WorkerToServerMessage,
+    Config, PacketBuffers, ServerToWorkerMessage, Uuid, WorkerToServerMessage, WrappedBanInfo,
 };
 use fecs::Entity;
 use once_cell::sync::Lazy;
@@ -84,6 +84,7 @@ impl NetworkIoManager {
     pub fn start(
         listener: TcpListener,
         config: Arc<Config>,
+        ban_info: WrappedBanInfo,
         player_count: Arc<AtomicU32>,
         server_icon: Arc<Option<String>>,
         packet_buffers: Arc<PacketBuffers>,
@@ -95,7 +96,7 @@ impl NetworkIoManager {
             listener,
             listener_tx.clone(),
             listener_rx,
-            config,
+            (config, ban_info),
             player_count,
             server_icon,
             packet_buffers,
@@ -125,7 +126,7 @@ async fn run_listener(
     listener: TcpListener,
     tx: flume::Sender<ListenerToServerMessage>,
     rx: flume::Receiver<ServerToListenerMessage>,
-    config: Arc<Config>,
+    config_bans: (Arc<Config>, WrappedBanInfo),
     player_count: Arc<AtomicU32>,
     server_icon: Arc<Option<String>>,
     packet_buffers: Arc<PacketBuffers>,
@@ -134,7 +135,7 @@ async fn run_listener(
         listener,
         tx,
         rx,
-        config,
+        config_bans,
         player_count,
         server_icon,
         packet_buffers,

--- a/server/network/src/listener.rs
+++ b/server/network/src/listener.rs
@@ -5,7 +5,7 @@
 
 use crate::worker::run_worker;
 use crate::{ListenerToServerMessage, ServerToListenerMessage};
-use feather_server_types::{Config, PacketBuffers};
+use feather_server_types::{Config, PacketBuffers, WrappedBanInfo};
 
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -17,7 +17,7 @@ pub async fn run_listener(
     mut listener: TcpListener,
     tx: flume::Sender<ListenerToServerMessage>,
     rx: flume::Receiver<ServerToListenerMessage>,
-    config: Arc<Config>,
+    config_bans: (Arc<Config>, WrappedBanInfo),
     player_count: Arc<AtomicU32>,
     server_icon: Arc<Option<String>>,
     packet_buffers: Arc<PacketBuffers>,
@@ -40,7 +40,8 @@ pub async fn run_listener(
             ip,
             tx.clone(),
             Arc::clone(&rx),
-            Arc::clone(&config),
+            Arc::clone(&config_bans.0),
+            Arc::clone(&config_bans.1),
             Arc::clone(&player_count),
             Arc::clone(&server_icon),
             Arc::clone(&packet_buffers),

--- a/server/network/src/worker.rs
+++ b/server/network/src/worker.rs
@@ -13,7 +13,7 @@ use feather_core::anvil::player::PlayerData;
 use feather_core::network::{MinecraftCodec, Packet, PacketDirection};
 use feather_core::util::{Position, Vec3d};
 use feather_server_types::{
-    Config, PacketBuffers, ServerToWorkerMessage, Uuid, WorkerToServerMessage,
+    BanInfo, Config, PacketBuffers, ServerToWorkerMessage, Uuid, WorkerToServerMessage,
 };
 use fecs::Entity;
 use futures::future::Either;
@@ -23,6 +23,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
+use std::sync::RwLock;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio_util::codec::Framed;
@@ -61,6 +62,7 @@ pub async fn run_worker(
     listener_tx: flume::Sender<ListenerToServerMessage>,
     listener_rx: Arc<Mutex<flume::Receiver<ServerToListenerMessage>>>,
     config: Arc<Config>,
+    ban_info: Arc<RwLock<BanInfo>>,
     player_count: Arc<AtomicU32>,
     server_icon: Arc<Option<String>>,
     packet_buffers: Arc<PacketBuffers>,
@@ -70,8 +72,10 @@ pub async fn run_worker(
 
     let initial_handler = Some(InitialHandler::new(
         Arc::clone(&config),
+        Arc::clone(&ban_info),
         Arc::clone(&player_count),
         Arc::clone(&server_icon),
+        ip,
     ));
 
     let codec = MinecraftCodec::new(PacketDirection::Serverbound);

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -8,7 +8,7 @@ use feather_server_chunk::{chunk_worker, ChunkWorkerHandle};
 use feather_server_config::DEFAULT_CONFIG_STR;
 use feather_server_network::NetworkIoManager;
 use feather_server_packet_buffer::PacketBuffers;
-use feather_server_types::{task, Config, Game, Shared, ShutdownChannels};
+use feather_server_types::{task, BanInfo, Config, Game, Shared, ShutdownChannels};
 use feather_server_worldgen::{
     ComposableGenerator, EmptyWorldGenerator, SuperflatWorldGenerator, WorldGenerator,
 };
@@ -17,7 +17,7 @@ use fxhash::FxHasher;
 use rand::Rng;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -40,6 +40,11 @@ pub async fn init(
         .await
         .context("Failed to load configuration file `feather.toml`")?;
     set_up_logging(&config).context("Failed to initialize logging")?;
+
+    log::info!("Loading ban list");
+    let ban_info = load_ban_info()
+        .await
+        .context("Failed to load ban list `bans.toml`")?;
 
     log::info!("Loading world save");
     let level = load_level(&config)
@@ -79,10 +84,14 @@ pub async fn init(
     feather_core::blocks::init();
 
     log::info!("Starting networking task");
-    let networking_handle =
-        create_networking_handle(Arc::clone(&config), &game, Arc::clone(&packet_buffers))
-            .await
-            .context("Failed to start the networking task")?;
+    let networking_handle = create_networking_handle(
+        Arc::clone(&config),
+        Arc::clone(&ban_info),
+        &game,
+        Arc::clone(&packet_buffers),
+    )
+    .await
+    .context("Failed to start the networking task")?;
 
     let resources = create_resources(
         resources,
@@ -90,6 +99,7 @@ pub async fn init(
         cworker_handle,
         networking_handle,
         packet_buffers,
+        ban_info,
     );
 
     Ok((executor, resources, world))
@@ -111,6 +121,18 @@ async fn load_config() -> anyhow::Result<Arc<Config>> {
         }
         Err(e) => Err(e.into()),
     }
+    .map(Arc::new)
+}
+
+async fn load_ban_info() -> anyhow::Result<Arc<RwLock<BanInfo>>> {
+    const PATH: &str = "bans.toml";
+
+    match File::open(PATH).await {
+        Ok(mut file) => BanInfo::load_from_file(&mut file).await,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(BanInfo::default()),
+        Err(e) => Err(e.into()),
+    }
+    .map(RwLock::new)
     .map(Arc::new)
 }
 
@@ -236,6 +258,7 @@ fn create_cworker_handle(config: &Config, level: &LevelData) -> ChunkWorkerHandl
 
 async fn create_networking_handle(
     config: Arc<Config>,
+    ban_info: Arc<RwLock<BanInfo>>,
     game: &Game,
     packet_buffers: Arc<PacketBuffers>,
 ) -> anyhow::Result<NetworkIoManager> {
@@ -253,6 +276,7 @@ async fn create_networking_handle(
     Ok(NetworkIoManager::start(
         socket,
         config,
+        ban_info,
         Arc::clone(&game.player_count),
         Arc::new(server_icon),
         packet_buffers,
@@ -304,6 +328,7 @@ fn create_resources(
     cworker_handle: ChunkWorkerHandle,
     networking_handle: NetworkIoManager,
     packet_buffers: Arc<PacketBuffers>,
+    ban_info: Arc<RwLock<BanInfo>>,
 ) -> Arc<OwnedResources> {
     let resources = {
         let resources = resources
@@ -311,6 +336,7 @@ fn create_resources(
             .with(cworker_handle)
             .with(networking_handle)
             .with(packet_buffers)
+            .with(ban_info)
             .with(ShutdownChannels::new());
         Arc::new(resources)
     };

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -4,13 +4,13 @@
 
 use feather_server_chunk::ChunkWorkerHandle;
 use feather_server_lighting::LightingWorkerHandle;
-use feather_server_types::{Game, ShutdownChannels, TPS};
+use feather_server_types::{BanInfo, Game, ShutdownChannels, TPS};
 use fecs::{Executor, OwnedResources, ResourcesProvider, World};
 use spin_sleep::LoopHelper;
 use std::ops::Deref;
 use std::panic::AssertUnwindSafe;
 use std::process::exit;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use tokio::runtime;
 
 mod event_handlers;
@@ -135,6 +135,8 @@ async fn shut_down(resources: &OwnedResources, world: &mut World) -> anyhow::Res
     shutdown::save_level(&mut *resources.get_mut::<Game>()).await?;
     log::info!("Saving player data");
     shutdown::save_player_data(&*resources.get::<Game>(), &world)?;
+    log::info!("Saving ban list");
+    shutdown::save_ban_list(&resources.get::<Arc<RwLock<BanInfo>>>()).await?;
     log::info!("Waiting for tasks to finish");
     shutdown::wait_for_task_completion().await?;
 

--- a/server/types/src/resources.rs
+++ b/server/types/src/resources.rs
@@ -1,4 +1,8 @@
+use std::sync::{Arc, RwLock};
+
 pub use crate::game::*;
 pub use crate::task::*;
-pub use feather_server_config::{Config, ProxyMode};
+pub use feather_server_config::{Ban, BanInfo, Config, ProxyMode};
+pub type WrappedBanInfo = Arc<RwLock<BanInfo>>;
+
 pub use feather_server_packet_buffer::{PacketBuffer, PacketBuffers};

--- a/server/util/Cargo.toml
+++ b/server/util/Cargo.toml
@@ -18,3 +18,7 @@ itertools = "0.9"
 ahash = "0.3"
 inventory = "0.1"
 anyhow = "1.0"
+uuid = { version = "0.8", features = ["v3"] }
+md5 = "0.7"
+reqwest = { version = "^0.10", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Implements /ban, /ban-ip, /pardon and /pardon-ip (#229). IP Bans are enforced before encryption is attempted, whereas UUID bans are enforced after authentication is performed.

When in online mode, `/pardon` uses the Mojang API to map the given name to a UUID.

Whilst ban expiry is supported, none of the implemented commands support adding expiring bans.