### PR TITLE
satisfy clippy match_like_matches_macro lint

### DIFF
--- a/core/blocks/src/categories.rs
+++ b/core/blocks/src/categories.rs
@@ -200,7 +200,7 @@ impl BlockId {
             | SimplifiedBlockKind::Fence
             | SimplifiedBlockKind::FenceGate
             | SimplifiedBlockKind::IronDoor
-            | SimplifiedBlockKind::Stairs 
+            | SimplifiedBlockKind::Stairs
             | SimplifiedBlockKind::WoodenDoor => Some(PlacementType::PlayerDirection),
             SimplifiedBlockKind::Anvil => Some(PlacementType::PlayerDirectionRightAngle),
             _ => None,

--- a/core/blocks/src/directions.rs
+++ b/core/blocks/src/directions.rs
@@ -117,10 +117,7 @@ impl FacingCubic {
     }
 
     pub fn is_horizontal(self) -> bool {
-        match self {
-            FacingCubic::Up | FacingCubic::Down => false,
-            _ => true,
-        }
+        !matches!(self, FacingCubic::Up | FacingCubic::Down)
     }
 
     pub fn to_facing_cardinal(self) -> Option<FacingCardinal> {

--- a/definitions/generator/src/generated.rs
+++ b/definitions/generator/src/generated.rs
@@ -221,10 +221,7 @@ fn generate_block<'a>(
             .map(|(&name, cb_index)| {
                 (
                     VecOrOne::One(name),
-                    ron::Value::Bool(match cb_index {
-                        VecOrOne::One(cb_index) if *cb_index == 1 => true,
-                        _ => false,
-                    }),
+                    ron::Value::Bool(matches!(cb_index, VecOrOne::One(cb_index) if *cb_index == 1)),
                 )
             })
             .collect(),

--- a/server/player/src/packet_handlers/digging.rs
+++ b/server/player/src/packet_handlers/digging.rs
@@ -533,8 +533,5 @@ fn find_arrow(inventory: &Inventory) -> Option<(SlotIndex, ItemStack)> {
 }
 
 fn is_arrow_item(item: Item) -> bool {
-    match item {
-        Item::Arrow | Item::SpectralArrow | Item::TippedArrow => true,
-        _ => false,
-    }
+    matches!(item, Item::Arrow | Item::SpectralArrow | Item::TippedArrow)
 }

--- a/server/worldgen/src/biomes/distorted_voronoi.rs
+++ b/server/worldgen/src/biomes/distorted_voronoi.rs
@@ -68,16 +68,16 @@ impl BiomeGenerator for DistortedVoronoiBiomeGenerator {
 
 /// Returns whether the given biome is allowed in the overworld.
 fn is_biome_allowed(biome: Biome) -> bool {
-    match biome {
+    !matches!(
+        biome,
         Biome::TheEnd
-        | Biome::TheVoid
-        | Biome::Nether
-        | Biome::SmallEndIslands
-        | Biome::EndBarrens
-        | Biome::EndHighlands
-        | Biome::EndMidlands => false,
-        _ => true,
-    }
+            | Biome::TheVoid
+            | Biome::Nether
+            | Biome::SmallEndIslands
+            | Biome::EndBarrens
+            | Biome::EndHighlands
+            | Biome::EndMidlands
+    )
 }
 
 #[cfg(test)]

--- a/server/worldgen/src/finishers/snow.rs
+++ b/server/worldgen/src/finishers/snow.rs
@@ -28,12 +28,12 @@ impl FinishingGenerator for SnowFinisher {
 }
 
 fn is_snowy_biome(biome: Biome) -> bool {
-    match biome {
+    matches!(
+        biome,
         Biome::SnowyTundra
-        | Biome::IceSpikes
-        | Biome::SnowyTaiga
-        | Biome::SnowyTaigaMountains
-        | Biome::SnowyBeach => true,
-        _ => false,
-    }
+            | Biome::IceSpikes
+            | Biome::SnowyTaiga
+            | Biome::SnowyTaigaMountains
+            | Biome::SnowyBeach
+    )
 }


### PR DESCRIPTION
Satisfies clippy by using the `matches!` macro where possible.
Also fixes a whitespace formatting error I introduced in #317 (sorry for that).
