### PR TITLE
Added check to handle user clicking inventory window with item in hand

### DIFF
--- a/server/player/src/packet_handlers/inventory.rs
+++ b/server/player/src/packet_handlers/inventory.rs
@@ -338,6 +338,11 @@ fn handle_single_click(
     packet: ClickWindow,
     button: MouseButton,
 ) -> anyhow::Result<()> {
+    // slot is -1 means user clicking in the current window
+    // but no on any slot, which should do nothing.
+    if packet.slot == -1 {
+        return Ok(());
+    }
     if let Some(picked) = world.try_get::<PickedItem>(player).map(|i| *i) {
         // Put down the item on the clicked slot. Based on the mouse button:
         // * left => whole stack


### PR DESCRIPTION
Clicking on inventory window with item in hand would kick player since the slot -1 is invalid.
https://user-images.githubusercontent.com/31701643/103684368-1fab3480-4f94-11eb-87a5-45e5bfb363ff.mp4

Added check for cases where the slot is -1 and nothing should be done.

