### PR TITLE
Implement `/setworldspawn` command

### DIFF
--- a/server/commands/src/impls.rs
+++ b/server/commands/src/impls.rs
@@ -10,8 +10,8 @@ use feather_core::text::{Text, TextComponentBuilder, TextValue};
 use feather_core::util::{Gamemode, Position};
 use feather_definitions::Item;
 use feather_server_types::{
-    Ban, ChatEvent, ChatPosition, GamemodeUpdateEvent, InventoryUpdateEvent, MessageReceiver, Name,
-    Player, ShutdownChannels, Teleported, WrappedBanInfo,
+    Ban, ChatEvent, ChatPosition, GamemodeUpdateEvent, InventoryUpdateEvent, LevelData,
+    MessageReceiver, Name, Player, ShutdownChannels, Teleported, WrappedBanInfo,
 };
 use feather_server_util::{name_to_uuid_offline, name_to_uuid_online};
 use fecs::{Entity, IntoQuery, Read, ResourcesProvider, World};
@@ -815,4 +815,35 @@ pub fn pardonip(ctx: &mut CommandCtx, ip: String) -> anyhow::Result<()> {
     }
 
     Ok(None)
+}
+
+#[command(usage = "setworldspawn")]
+pub fn setworldspawn_currentpos(ctx: &mut CommandCtx) -> anyhow::Result<()> {
+    let position = ctx.world.get::<Position>(ctx.sender);
+
+    setworldspawn(&mut ctx.game.level, position.as_ref())
+}
+
+#[command(usage = "setworldspawn <location>")]
+pub fn setworldspawn_specificpos(
+    ctx: &mut CommandCtx,
+    location: Coordinates,
+) -> anyhow::Result<()> {
+    let new_pos = ctx
+        .world
+        .try_get::<Position>(ctx.sender)
+        .map(|r| *r)
+        .map(|relative_to| location.into_position(relative_to))
+        .unwrap();
+    setworldspawn(&mut ctx.game.level, &new_pos)
+}
+
+fn setworldspawn(level: &mut LevelData, position: &Position) -> anyhow::Result<Option<String>> {
+    level.spawn_x = position.x as i32;
+    level.spawn_y = position.y as i32;
+    level.spawn_z = position.z as i32;
+    Ok(Some(format!(
+        "Set world spawn to {0}, {1}, {2}",
+        level.spawn_x, level.spawn_y, level.spawn_z
+    )))
 }

--- a/server/commands/src/lib.rs
+++ b/server/commands/src/lib.rs
@@ -130,6 +130,9 @@ impl CommandState {
 
                 pardon,
                 pardonip,
+
+                setworldspawn_currentpos,
+                setworldspawn_specificpos,
         }
 
         Self {

--- a/server/types/src/game.rs
+++ b/server/types/src/game.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use ahash::AHashMap;
 use bumpalo::Bump;
-use feather_core::anvil::level::LevelData;
+pub use feather_core::anvil::level::LevelData;
 use feather_core::blocks::BlockId;
 use feather_core::chunk_map::ChunkMap;
 use feather_core::game_rules::GameRules;


### PR DESCRIPTION
The command just updates the `LevelData` State in `ctx.game`. From which the next time `LevelData` is saved to disk will be permanent.
The `angle` parameter was not implemented, as it is only added in 1.16.

completes a point on #229 