### PR TITLE
text-api 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "feather-text"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "feather-utils"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/common",
     "crates/protocol",
     "crates/server",
+    "crates/text",
 
     "tools/proxy",
 ]

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "feather-text"
+version = "0.1.0"
+authors = ["= <jacob@rosborg.dk>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/crates/text/src/click_event.rs
+++ b/crates/text/src/click_event.rs
@@ -1,0 +1,69 @@
+use serde::{Serialize, Deserialize};
+use std::borrow::Cow;
+
+use crate::Text;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "action", content = "value")]
+pub enum ClickEvent<'a> {
+    /// Opens the given URL in the default web browser.
+    /// Ignored if the player has opted to disable links in chat; may open a GUI prompting the user if the setting for that is enabled.
+    /// The link's protocol must be set and must be http or https, for security reasons.
+    OpenUrl(Cow<'a, str>),
+    /// In chat and written books, this value is sent in chat as though the player typed it themselves and pressed enter.
+    /// If used in a book GUI, the GUI is closed after clicking.
+    /// This can be used to run commands, provided the player has the required permissions.
+    /// Since they are being run from chat, commands must be prefixed with the usual "/" slash.
+    /// Works in signs, but only on the root text component, not on any children.
+    /// Activated by using the sign and the command is run by the server at the sign's location, with the player who used the sign as @s.
+    /// Since they are run by the server, sign commands have the same permission level as a command block instead of using the player's permission level,
+    /// are not restricted by chat length limits, and do not need to be prefixed with a "/" slash.
+    RunCommand(Cow<'a, str>),
+    /// Only usable for messages in chat. 
+    /// Replaces the content of the chat box with the given text - usually a command, but it is not required to be a command (commands should be prefixed with /).
+    SuggestCommand(Cow<'a, str>),
+    /// Only usable within written books. 
+    /// Changes the page of the book to the given page, starting at 1.
+    /// If the page is less than one or beyond the number of pages in the book, the event is ignored.
+    ChangePage(u8),
+}
+
+impl<'a> ClickEvent<'a> {
+    pub fn open_url<T: Into<Cow<'a, str>>>(link: T) -> Self {
+        ClickEvent::OpenUrl(link.into())
+    }
+
+    pub fn run_command<T: Into<Cow<'a, str>>>(command: T) -> Self {
+        ClickEvent::RunCommand(command.into())
+    }
+
+    pub fn suggest_command<T: Into<Cow<'a, str>>>(command: T) -> Self {
+        ClickEvent::SuggestCommand(command.into())
+    }
+
+    pub fn change_page(page: u8) -> Self {
+        ClickEvent::ChangePage(page)
+    }
+}
+
+impl<'a> Text<'a> {
+    pub fn on_click_open_url<T: Into<Cow<'a, str>>>(mut self, link: T) -> Self {
+        self.click_event = Some(ClickEvent::open_url(link));
+        self
+    }
+
+    pub fn on_click_run_command<T: Into<Cow<'a, str>>>(mut self, command: T) -> Self {
+        self.click_event = Some(ClickEvent::run_command(command));
+        self
+    }
+
+    pub fn on_click_suggest_command<T: Into<Cow<'a, str>>>(mut self, command: T) -> Self {
+        self.click_event = Some(ClickEvent::suggest_command(command));
+        self
+    }
+
+    pub fn on_click_change_page(mut self, page: u8) -> Self {
+        self.click_event = Some(ClickEvent::change_page(page));
+        self
+    }
+}

--- a/crates/text/src/color.rs
+++ b/crates/text/src/color.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+use std::{convert::TryFrom, borrow::Cow};
+use super::Text;
+
+macro_rules! colors {
+    {$($ident:ident => $name:ident),* $(,)?} => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+        #[serde(try_from = "&str", into = "Cow<'static, str>")]
+        pub enum Color {
+            $($ident,)*
+            Rgb(u8, u8, u8)
+        }
+
+        impl TryFrom<&str> for Color {
+            type Error = &'static str;
+
+            fn try_from(name: &str) -> Result<Self, Self::Error> {
+                match name {
+                    $(stringify!($name) => Ok(Color::$ident),)*
+                    "#000000" => Ok(Color::Rgb(0x00, 0x00, 0x00)),
+                    _ => Err("not a valid color"),
+                }
+            }
+        }
+
+        impl From<(u8, u8, u8)> for Color {
+            fn from((r, g, b): (u8, u8, u8)) -> Self {
+                Color::Rgb(r, g, b)
+            }
+        }
+
+        impl Into<Cow<'static, str>> for Color {
+            fn into(self) -> Cow<'static, str> {
+                match self {
+                    $(Color::$ident => Cow::from(stringify!($name)),)*
+                    Color::Rgb(r, g, b) => Cow::from(format!("#{:02X}{:02X}{:02X}", r, g, b)),
+                }
+            }
+        }
+
+        impl<'a> Text<'a> {
+            $(
+            pub fn $name(self) -> Self {
+                self.color(Color::$ident)
+            }
+            )*
+        }
+    };
+}
+
+colors! {
+    Black       => black,
+    DarkBlue    => dark_blue,
+    DarkGreen   => dark_green,
+    DarkAqua    => dark_aqua,
+    DarkRed     => dark_red,
+    DarkPurple  => dark_purple,
+    Gold        => gold,
+    Gray        => gray,
+    DarkGray    => dark_gray,
+    Blue        => blue,
+    Green       => green,
+    Aqua        => aqua,
+    Red         => red,
+    LightPurple => light_purple,
+    Yellow      => yellow,
+    White       => white,
+    Reset       => reset,
+}

--- a/crates/text/src/content.rs
+++ b/crates/text/src/content.rs
@@ -1,0 +1,68 @@
+use super::{Text, ExtraVec};
+use serde::{Serialize, Deserialize};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
+pub enum Content<'a> {
+    /// A string containing plain text to display directly. Can also be a number or boolean that is displayed directly.
+    Text { text: Cow<'a, str> },
+    //// Displays a translated piece of text from the currently selected language. 
+    /// This uses the client's selected language, so if players with their games set to different languages are logged into the same server, each will see the component in their own language.
+    /// Translations are defined in language files in resource packs, including the built-in resource pack.
+    /// Translations can contain slots for text that is not known ahead of time, such as player names. When displaying the translated text, slots will be filled from a provided list of text components. 
+    /// The slots are defined in the language file, and generally take the form %s (displays the next component in the list), or %3$s (displays the third component in the list; replace 3 with whichever index is desired).
+    /// For example, the built-in English language file contains the translation "chat.type.advancement.task": "%s has made the advancement %s",. 
+    Translation {
+        translate: Cow<'a, str>,
+        #[serde(with = "ExtraVec")]
+        with: Vec<Text<'a>>,
+    },
+    /// Displays the name of the button that is currently bound to a certain configurable control. 
+    /// This uses the client's own control scheme, so if players with different control schemes are logged into the same server, each will see their own keybind. 
+    Keybind {
+        keybind: Cow<'a, str>
+    },
+}
+
+impl<'a> Default for Content<'a> {
+    fn default() -> Self {
+        Content::text("")
+    }
+}
+
+impl<'a> Content<'a> {
+    pub fn text<T: Into<Cow<'a, str>>>(text: T) -> Self {
+        Content::Text { text: text.into() }
+    }
+
+    pub fn translation<T: Into<Cow<'a, str>>>(translate: T, with: Vec<Text<'a>>) -> Self {
+        Content::Translation {
+            translate: translate.into(),
+            with,
+        }
+    }
+
+}
+
+macro_rules! is_content {
+    {$($ident:ident => $is_ident:ident),*$(,)?} => {
+        impl<'a> Content<'a> {
+            $(
+            pub fn $is_ident(&self) -> bool {
+                match self {
+                    Content::$ident { .. } => true,
+                    _ => false,
+                }
+            }
+            )*
+        }
+    };
+}
+
+is_content! {
+    Text        => is_text,
+    Translation => is_translation,
+    Keybind     => is_keybind,
+}

--- a/crates/text/src/hover_event.rs
+++ b/crates/text/src/hover_event.rs
@@ -1,0 +1,14 @@
+use serde::{Serialize, Deserialize};
+use super::Text;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "action", content = "value")]
+pub enum HoverEvent<'a> {
+    ShowText(Box<Text<'a>>),
+    ShowItem(ItemStack),
+    ShowEntity(LivingEntity),
+}
+
+pub type Uuid = ();
+pub type ItemStack = ();
+pub type LivingEntity = ();

--- a/crates/text/src/keybind.rs
+++ b/crates/text/src/keybind.rs
@@ -1,0 +1,66 @@
+use std::borrow::Cow;
+
+macro_rules! keybinds {
+    {$($ident:ident => $name:literal),* $(,)?} => {
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum Keybind<'a> {
+            $($ident,)*
+            Custom(Cow<'a, str>)
+        }
+
+        impl<'a> From<&'a str> for Keybind<'a> {
+
+            fn from(bind: &'a str) -> Self {
+                match bind {
+                    $($name => Keybind::$ident,)*
+                    _ => Keybind::Custom(Cow::<'a>::from(bind)),
+                }
+            }
+        }
+
+        impl<'a> Into<Cow<'a, str>> for Keybind<'a> {
+            fn into(self) -> Cow<'a, str> {
+                match self {
+                    $(Keybind::$ident => Cow::from($name),)*
+                    Keybind::Custom(bind) => bind,
+                }
+            }
+        }
+    };
+}
+
+keybinds! {
+    Attack              => "key_key.attack",
+    UseItem             => "key_key.use",
+    Forward             => "key_key.forward",
+    Left                => "key_key.left",
+    Back                => "key_key.back",
+    Right               => "key_key.right",
+    Jump                => "key_key.jump",
+    Sneak               => "key_key.sneak",
+    Sprint              => "key_key.sprint",
+    Drop                => "key_key.drop",
+    Inventory           => "key_key.inventory",
+    Chat                => "key_key.chat",
+    ListPlayers         => "key_key.playerlist",
+    PickBlock           => "key_key.pickItem",
+    Command             => "key_key.command",
+    Screenshot          => "key_key.screenshot",
+    Perspective         => "key_key.togglePerspective",
+    MouseSmoothing      => "key_key.smoothCamera",
+    Fullscreen          => "key_key.fullscreen",
+    SpectatorOutlines   => "key_key.spectatorOutlines",
+    SwapHands           => "key_key.swapHands",
+    SaveToolbar         => "key_key.saveToolbarActivator",
+    LoadToolbar         => "key_key.loadToolbarActivator",
+    Advancements        => "key_key.advancements",
+    Hotbar1             => "key_key.hotbar.1",
+    Hotbar2             => "key_key.hotbar.2",
+    Hotbar3             => "key_key.hotbar.3",
+    Hotbar4             => "key_key.hotbar.4",
+    Hotbar5             => "key_key.hotbar.5",
+    Hotbar6             => "key_key.hotbar.6",
+    Hotbar7             => "key_key.hotbar.7",
+    Hotbar8             => "key_key.hotbar.8",
+    Hotbar9             => "key_key.hotbar.9",
+}

--- a/crates/text/src/lib.rs
+++ b/crates/text/src/lib.rs
@@ -1,0 +1,365 @@
+mod click_event;
+mod color;
+mod content;
+mod hover_event;
+mod keybind;
+mod style;
+mod simplifier;
+
+pub use click_event::*;
+pub use color::*;
+pub use content::*;
+pub use hover_event::*;
+pub use keybind::*;
+pub use style::*;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
+
+/// A way to propperly serialize and deserialize extra components.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum Extra<'a> {
+    String(Cow<'a, str>),
+    Object(Text<'a>),
+    Array(Vec<Text<'a>>),
+}
+
+impl<'a> From<Text<'a>> for Extra<'a> {
+    fn from(text: Text<'a>) -> Self {
+        // Shoud be colapsed into a function on Text, just don't know what to name it.
+        // !has_atributes?
+        if text.color.is_none()
+            && text.bold.is_none()
+            && text.italic.is_none()
+            && text.obfuscated.is_none()
+            && text.hover_event.is_none()
+            && text.extra.is_empty()
+            && text.click_event.is_none()
+            && text.font.is_none()
+            && text.insertion.is_none()
+            && text.strikethrough.is_none()
+            && text.underlined.is_none()
+        {
+            if let Content::Text { text } = text.content {
+                return Extra::String(text);
+            }
+        }
+        // Should be colapsed into a function Text, just don't know what to name it.
+        // !has_atributes_other_than_extra?
+        if text.color.is_none()
+            && text.bold.is_none()
+            && text.italic.is_none()
+            && text.obfuscated.is_none()
+            && text.hover_event.is_none()
+            && text.click_event.is_none()
+            && text.font.is_none()
+            && text.insertion.is_none()
+            && text.strikethrough.is_none()
+            && text.underlined.is_none()
+        {
+            if let Content::Text {
+                text: Cow::Borrowed(""),
+            } = text.content
+            {
+                return Extra::Array(text.extra);
+            }
+        }
+
+        Extra::Object(text)
+    }
+}
+
+struct ExtraVec;
+
+impl ExtraVec {
+    #[inline]
+    fn serialize<'a, S>(texts: &Vec<Text<'a>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bars: Vec<Extra> = texts.iter().map(|text| Extra::from(text.clone())).collect();
+        Serialize::serialize(&bars, serializer)
+    }
+}
+
+impl ExtraVec {
+    #[inline]
+    fn deserialize<'a, 'de, D>(deserializer: D) -> Result<Vec<Text<'a>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let extras: Vec<Extra> = Deserialize::deserialize(deserializer)?;
+        let extras: Vec<Text> = extras
+            .into_iter()
+            .flat_map(|extra| match extra {
+                Extra::String(text) => vec![Text::of(text)].into_iter(),
+                Extra::Object(text) => vec![text].into_iter(),
+                Extra::Array(array) => array.into_iter(),
+            })
+            .collect();
+        Ok(extras)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+pub struct Text<'a> {
+    /// TODO
+    #[serde(flatten)]
+    pub content: Content<'a>,
+    /// A list of additional raw JSON text components to be displayed after this one.
+    /// They inherent the formatting of their parent.???
+    #[serde(skip_serializing_if = "Vec::is_empty", with = "ExtraVec")]
+    pub extra: Vec<Text<'a>>,
+    /// The resource location of the font for this component in the resource pack within `assets/<namespace>/font`.
+    /// Defaults to `"minecraft:default"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font: Option<Cow<'a, str>>,
+    /// The color to render the content in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<Color>,
+    /// Whether to render the content in bold.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bold: Option<bool>,
+    /// Whether to render the content in italics.
+    /// Note that text that is italicized by default, such as custom item names, can be unitalicized by setting this to false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub italic: Option<bool>,
+    /// Whether to underline the content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underlined: Option<bool>,
+    /// Whether to strikethrough the content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strikethrough: Option<bool>,
+    /// Whether the component should randomly switch between characters of the same width.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub obfuscated: Option<bool>,
+    /// When the text is shift-clicked by a player, this string is inserted in their chat input.
+    /// It does not overwrite any existing text the player was writing. This only works in chat messages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub insertion: Option<Cow<'a, str>>,
+    /// Allows for events to occur when the player clicks on text. Only work in chat messages and written books, unless specified otherwise.
+    #[serde(rename = "clickEvent", skip_serializing_if = "Option::is_none")]
+    pub click_event: Option<ClickEvent<'a>>,
+    /// Allows for a tooltip to be displayed when the player hovers their mouse over text.
+    #[serde(rename = "hoverEvent", skip_serializing_if = "Option::is_none")]
+    pub hover_event: Option<HoverEvent<'a>>,
+}
+
+impl<'a> Text<'a> {
+    pub fn of<T: Into<Cow<'a, str>>>(text: T) -> Self {
+        Text {
+            content: Content::text(text),
+            ..Default::default()
+        }
+    }
+
+    pub fn translation<T: Into<Cow<'a, str>>>(translate: T, with: Vec<Text<'a>>) -> Self {
+        Text {
+            content: Content::translation(translate, with),
+            ..Default::default()
+        }
+    }
+
+    pub fn extra(mut self, text: Text<'a>) -> Self {
+        self.extra.push(text);
+        self
+    }
+
+    pub fn color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    pub fn clear_color(mut self) -> Self {
+        self.color = None;
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        match style {
+            Style::Obfuscated => self.obfuscated = Some(true),
+            Style::Bold => self.bold = Some(true),
+            Style::Strikethrough => self.strikethrough = Some(true),
+            Style::Underlined => self.underlined = Some(true),
+            Style::Italic => self.italic = Some(true),
+        }
+        self
+    }
+
+    pub fn not_style(mut self, style: Style) -> Self {
+        match style {
+            Style::Obfuscated => self.obfuscated = Some(false),
+            Style::Bold => self.bold = Some(false),
+            Style::Strikethrough => self.strikethrough = Some(false),
+            Style::Underlined => self.underlined = Some(false),
+            Style::Italic => self.italic = Some(false),
+        }
+        self
+    }
+
+    // TODO: Text::style_clear_all
+    pub fn clear_style(mut self, style: Style) -> Self {
+        match style {
+            Style::Obfuscated => self.obfuscated = None,
+            Style::Bold => self.bold = None,
+            Style::Strikethrough => self.strikethrough = None,
+            Style::Underlined => self.underlined = None,
+            Style::Italic => self.italic = None,
+        }
+        self
+    }
+
+    pub fn insertion<S: Into<Cow<'a, str>>>(mut self, value: S) -> Self {
+        let value = value.into();
+        // TODO: is there a difference betwteen None and Some("")?
+        if value.is_empty() {
+            self.insertion = None;
+        } else {
+            self.insertion = Some(value);
+        }
+        self
+    }
+
+    pub fn on_click(mut self, click_event: ClickEvent<'a>) -> Self {
+        self.click_event = Some(click_event);
+        self
+    }
+
+    pub fn clear_on_click(mut self) -> Self {
+        self.click_event = None;
+        self
+    }
+
+    pub fn append(self, text: Text<'a>) -> Self {
+        Text::of("").extra(self).extra(text)
+    }
+
+    pub fn has_color(&self) -> bool {
+        self.color.is_none()
+    }
+
+    pub fn has_style(&self) -> bool {
+        self.bold.is_some()
+            && self.italic.is_some()
+            && self.obfuscated.is_some()
+            && self.strikethrough.is_some()
+            && self.underlined.is_some()
+    }
+
+    // is_bold? Bold can either be None, Some(false), and Some(true).
+    // Maybe a has_bold instead? self.bold.is_some()
+}
+
+impl<'a> From<Vec<Text<'a>>> for Text<'a> {
+    fn from(extra: Vec<Text<'a>>) -> Self {
+        let mut text = Text::of("");
+        text.extra = extra;
+        text
+    }
+}
+
+// More and better tests
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn simple() {
+        assert_eq!(
+            json!({
+                "text": "Some basic text, with no formatting at all!",
+            }),
+            serde_json::to_value(Text::of("Some basic text, with no formatting at all!")).unwrap()
+        );
+    }
+
+    #[test]
+    fn with_color() {
+        Text::of("Red colored text!").red();
+        Text::of("Red colored text!").color(Color::Red);
+    }
+
+    #[test]
+    fn with_single_style() {}
+
+    #[test]
+    fn multiple_styles() {}
+
+    #[test]
+    fn complex() {
+        let complex_json = json!({
+            "text": "Complex text",
+            "extra": [{
+                "text": "Un formatted extra",
+            }, {
+                "translate": "Formatted translation",
+                "with": [],
+                "color": "gold",
+                "bold": true,
+                "italic": false,
+            }],
+            "italic": true,
+            "clickEvent": {
+                "action": "open_url",
+                "value": "https://feather.rs",
+            }
+        });
+
+        let complex_text = Text::of("Complex text")
+            .extra(Text::of("Un formatted extra"))
+            .extra(
+                Text::translation("Formatted translation", vec![])
+                    .gold()
+                    .bold()
+                    .not_italic(),
+            )
+            .italic()
+            .on_click_open_url("https://feather.rs");
+
+        assert_eq!(complex_json, serde_json::to_value(complex_text).unwrap())
+    }
+
+    #[test]
+    fn custom_deserializing() {
+        let json_value = json!({
+            "text": "Hello",
+            "extra": [" ", "world"],
+        });
+
+        let json_text: Text = serde_json::from_value(json_value.clone()).unwrap();
+
+        let text = Text::of("Hello")
+            .extra(Text::of(" "))
+            .extra(Text::of("world"));
+
+        assert_eq!(json_text, text);
+
+        let text_value = serde_json::to_value(text).unwrap();
+        assert_eq!(json_value, text_value);
+    }
+
+    #[test]
+    fn custom_serializing() {
+        assert_eq!(
+            json!({
+                "text": "",
+                "extra": vec!["Hello", " ", "world"],
+            }),
+            serde_json::to_value(Text::from(vec![
+                Text::of("Hello").red(),
+                Text::of(" "),
+                Text::of("world").blue(),
+            ]))
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn json() {
+        let json = serde_json::to_string_pretty(&Text::of("hello world").red().bold()).unwrap();
+        println!("{}", json);
+    }
+}

--- a/crates/text/src/simplifier.rs
+++ b/crates/text/src/simplifier.rs
@@ -1,0 +1,28 @@
+use std::mem;
+
+use crate::Text;
+
+impl<'a> Text<'a> {
+    pub fn simplify(mut self) -> Self {
+        let extra = mem::take(&mut self.extra);
+        let extra = extra.into_iter().filter_map(|mut extra| {
+            if extra.color == self.color {
+                extra.color = None;
+            }
+            if extra.bold == self.bold {
+                extra.bold = None;
+            }
+            if extra.italic == self.italic {
+                extra.italic = None;
+            }
+            if self.content.is_text() {
+                self.content = extra.content;
+                None
+            } else {
+                Some(extra)
+            }
+        });
+        self.extra = extra.collect();
+        todo!()
+    }
+}

--- a/crates/text/src/style.rs
+++ b/crates/text/src/style.rs
@@ -1,0 +1,80 @@
+use std::convert::TryFrom;
+use super::Text;
+
+macro_rules! styles {
+    {$($ident:ident => $name:ident),* $(,)?} => {
+        #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub enum Style {
+            $($ident,)*
+        }
+
+        impl TryFrom<&str> for Style {
+            type Error = ();
+
+            fn try_from(name: &str) -> Result<Self, Self::Error> {
+                match name {
+                    $(stringify!($name) => Ok(Style::$ident),)*
+                    _ => Err(()),
+                }
+            }
+        }
+
+        impl Into<&'static str> for Style {
+            fn into(self) -> &'static str {
+                match self {
+                    $(Style::$ident => stringify!($name),)*
+                }
+            }
+        }
+
+        impl<'a> Text<'a> {
+            $(pub fn $name(self) -> Self {
+                self.style(Style::$ident)
+            })*
+        }
+    };
+}
+
+styles! {
+    Obfuscated      => obfuscated,
+    Bold            => bold,
+    Strikethrough   => strikethrough,
+    Underlined      => underlined,
+    Italic          => italic,
+}
+
+macro_rules! not_style {
+    {$($ident:ident => $name:ident),* $(,)?} => {
+        impl<'a> Text<'a> {
+            $(pub fn $name(self) -> Self {
+                self.not_style(Style::$ident)
+            })*
+        }
+    };
+}
+
+not_style! {
+    Obfuscated      => not_obfuscated,
+    Bold            => not_bold,
+    Strikethrough   => not_strikethrough,
+    Underlined      => not_underlined,
+    Italic          => not_italic,
+}
+
+macro_rules! clear_style {
+    {$($ident:ident => $name:ident),* $(,)?} => {
+        impl<'a> Text<'a> {
+            $(pub fn $name(self) -> Self {
+                self.clear_style(Style::$ident)
+            })*
+        }
+    };
+}
+
+clear_style! {
+    Obfuscated      => clear_obfuscated,
+    Bold            => clear_bold,
+    Strikethrough   => clear_strikethrough,
+    Underlined      => clear_underlined,
+    Italic          => clear_italic,
+}


### PR DESCRIPTION
# Text-api 2.0
The text api now only support builder pattern like

## Todo
1. Test cases
2. Simplification
3. Cleanup and a few utility function that I don't know what to name.
4. Parsing of color codes

Also should we implement `From<Cow<'a, str>> for Text<'a>`?