### PR TITLE
Update GitHub Actions config to use new main branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ develop, master, staging ]
+    branches: [ main ]
   pull_request:
-    branches: [ develop, master, staging ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The main branch was renamed from `develop` to `main`.