### PR TITLE
CI: Use GNU tar on macOS to work around actions/cache#403

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,23 +31,23 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-registry2-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-registry-
+          ${{ runner.os }}-cargo-registry2-
     - name: Cache cargo index
       uses: actions/cache@v2
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-index2-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-index-
+          ${{ runner.os }}-cargo-index2-
     - name: Cache cargo build
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target2-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-build-target-
+          ${{ runner.os }}-cargo-build-target2-
 
     - name: Install rustfmt
       run: rustup component add rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,15 @@ jobs:
     - uses: actions/checkout@v2
 
     # Caching
+
+    # Work around https://github.com/actions/cache/issues/403 by using GNU tar
+    # instead of BSD tar.
+    - name: Install GNU tar
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install gnu-tar
+        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+
     - name: Cache cargo registry
       uses: actions/cache@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     # Work around https://github.com/actions/cache/issues/403 by using GNU tar
     # instead of BSD tar.
     - name: Install GNU tar
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-10.15'
       run: |
         brew install gnu-tar
         echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
We're having more spurious CI failures caused by

```
error[E0463]: can't find crate for `num_derive`
 --> crates/generated/src/block.rs:3:5
  |
3 |     num_derive::FromPrimitive,
  |     ^^^^^^^^^^ can't find crate

error: aborting due to previous error
```

Taken from rust-analyzer's CI configuration.