### PR TITLE
Moves interaction events to quill

### DIFF
--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ahash = "0.7"
 anyhow = "1"
-hecs = { git = "https://github.com/feather-rs/feather-hecs" }
+hecs = { git = "https://github.com/feather-rs/feather-hecs", features = ["serde"] }
 log = "0.4"
 thiserror = "1"
 utils = { path = "../utils", package = "feather-utils" }

--- a/crates/server/src/packet_handlers/interaction.rs
+++ b/crates/server/src/packet_handlers/interaction.rs
@@ -7,7 +7,10 @@ use protocol::packets::client::{
     BlockFace, InteractEntity, InteractEntityKind, PlayerBlockPlacement, PlayerDigging,
     PlayerDiggingStatus,
 };
-use quill_common::events::{BlockInteractEvent, BlockPlacementEvent, InteractEntityEvent};
+use quill_common::{
+    events::{BlockInteractEvent, BlockPlacementEvent, InteractEntityEvent},
+    EntityId,
+};
 
 /// Handles the player block placement packet. Currently just removes the block client side for the player.
 pub fn handle_player_block_placement(
@@ -148,14 +151,14 @@ pub fn handle_interact_entity(
 
     let event = match packet.kind {
         InteractEntityKind::Attack => InteractEntityEvent {
-            target,
+            target: EntityId(target.id() as u64),
             ty: InteractionType::Attack,
             target_pos: None,
             hand: None,
             sneaking: packet.sneaking,
         },
         InteractEntityKind::Interact => InteractEntityEvent {
-            target,
+            target: EntityId(target.id() as u64),
             ty: InteractionType::Interact,
             target_pos: None,
             hand: None,
@@ -174,7 +177,7 @@ pub fn handle_interact_entity(
             };
 
             InteractEntityEvent {
-                target,
+                target: EntityId(target.id() as u64),
                 ty: InteractionType::Attack,
                 target_pos: Some(Vec3f::new(
                     target_x as f32,

--- a/crates/server/src/packet_handlers/interaction.rs
+++ b/crates/server/src/packet_handlers/interaction.rs
@@ -1,15 +1,13 @@
 use crate::{ClientId, NetworkId, Server};
+use common::interactable::InteractableRegistry;
 use common::Game;
-use common::{
-    events::{BlockInteractEvent, BlockPlacementEvent, InteractEntityEvent},
-    interactable::InteractableRegistry,
-};
 use ecs::{Entity, SysResult};
 use libcraft_core::{BlockFace as LibcraftBlockFace, Hand, InteractionType, Vec3f};
 use protocol::packets::client::{
     BlockFace, InteractEntity, InteractEntityKind, PlayerBlockPlacement, PlayerDigging,
     PlayerDiggingStatus,
 };
+use quill_common::events::{BlockInteractEvent, BlockPlacementEvent, InteractEntityEvent};
 
 /// Handles the player block placement packet. Currently just removes the block client side for the player.
 pub fn handle_player_block_placement(


### PR DESCRIPTION
Requires the quill and libcraft PR for tests to pass. There might also be issues with locked revisions on the git deps but I promise this builds on my machine and will build once we set up the monorepo.