### PR TITLE
HList and Plucker for components

### DIFF
--- a/quill/api/src/hlist.rs
+++ b/quill/api/src/hlist.rs
@@ -99,14 +99,6 @@ pub trait Plucker<Target, Index> {
     fn pluck(self) -> (Target, Self::Remainder);
 }
 
-pub trait PluckerRef<Target, Index> {
-    fn pluck(&self) -> &Target;
-}
-
-pub trait PluckerRefMut<Target, Index> {
-    fn pluck(&mut self) -> &mut Target;
-}
-
 struct Here {}
 
 impl<Target, Tail> Plucker<Target, Here> for HCons<Target, Tail> {
@@ -115,20 +107,6 @@ impl<Target, Tail> Plucker<Target, Here> for HCons<Target, Tail> {
     #[inline]
     fn pluck(self) -> (Target, Self::Remainder) {
         (self.head, self.tail)
-    }
-}
-
-impl<Target, Tail> PluckerRef<Target, Here> for HCons<Target, Tail> {
-    #[inline]
-    fn pluck(&self) -> &Target {
-        &self.head
-    }
-}
-
-impl<Target, Tail> PluckerRefMut<Target, Here> for HCons<Target, Tail> {
-    #[inline]
-    fn pluck(&mut self) -> &mut Target {
-        &mut self.head
     }
 }
 
@@ -151,25 +129,5 @@ where
                 tail: tail_remainder,
             },
         )
-    }
-}
-
-impl<Target, Head, Tail, TailIndex> PluckerRef<Target, There<TailIndex>> for HCons<Head, Tail>
-where
-    Tail: PluckerRef<Target, TailIndex>,
-{
-    #[inline]
-    fn pluck(&self) -> &Target {
-        <Tail as PluckerRef<Target, TailIndex>>::pluck(&self.tail)
-    }
-}
-
-impl<Target, Head, Tail, TailIndex> PluckerRefMut<Target, There<TailIndex>> for HCons<Head, Tail>
-where
-    Tail: PluckerRefMut<Target, TailIndex>,
-{
-    #[inline]
-    fn pluck(&mut self) -> &mut Target {
-        <Tail as PluckerRefMut<Target, TailIndex>>::pluck(&mut self.tail)
     }
 }

--- a/quill/api/src/hlist.rs
+++ b/quill/api/src/hlist.rs
@@ -72,7 +72,7 @@ macro_rules! hlist_pat {
     () => { () };
     ($head:ident $(,$tail:ident)* $(,)?) => {
         HCons {
-            head: $head, 
+            head: $head,
             tail: hlist_pat!($($tail),*)
         }
     };
@@ -93,7 +93,7 @@ macro_rules! impl_tuple {
 
         impl<'a, $head $(,$tail)*> HListRef<'a> for HList!(&'a $head $(,&'a $tail)*) {
             type Tuple = (&'a $head, $(&'a $tail),*);
-        
+
             #[inline]
             fn flatten(&'a self) -> Self::Tuple {
                 #[allow(non_snake_case)]
@@ -118,7 +118,7 @@ macro_rules! impl_tuple {
 
         impl<'a, $head $(,$tail)*> TupleRef<'a> for (&'a $head, $(&'a $tail),*) {
             type HList = HCons<&'a $head, <($(&'a $tail,)*) as Tuple>::HList>;
-        
+
             #[inline]
             fn hlist(&'a self) -> Self::HList {
                 #[allow(non_snake_case)]
@@ -146,7 +146,6 @@ smaller_tuples_too!(
     impl_tuple, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
     T19, T20
 );
-
 
 pub trait Plucker<Target, Index> {
     type Remainder;
@@ -198,7 +197,8 @@ where
     }
 }
 
-impl<'a, Target, Head, Tail, TailIndex> PluckerRef<Target, There<TailIndex>> for HCons<&'a Head, Tail>
+impl<'a, Target, Head, Tail, TailIndex> PluckerRef<Target, There<TailIndex>>
+    for HCons<&'a Head, Tail>
 where
     Tail: PluckerRef<Target, TailIndex>,
 {
@@ -207,4 +207,3 @@ where
         <Tail as PluckerRef<Target, TailIndex>>::pluck(&self.tail)
     }
 }
-

--- a/quill/api/src/hlist.rs
+++ b/quill/api/src/hlist.rs
@@ -1,0 +1,175 @@
+use std::marker::PhantomData;
+
+pub struct HCons<Head, Tail> {
+    pub head: Head,
+    pub tail: Tail,
+}
+
+pub trait HList: Sized {
+    type Tuple: Tuple<HList = Self>;
+
+    fn flatten(self) -> Self::Tuple;
+}
+
+pub trait Tuple: Sized {
+    type HList: HList<Tuple = Self>;
+
+    fn hlist(self) -> Self::HList;
+}
+
+impl HList for () {
+    type Tuple = ();
+
+    #[inline]
+    fn flatten(self) -> Self::Tuple {}
+}
+
+impl Tuple for () {
+    type HList = ();
+
+    #[inline]
+    fn hlist(self) -> Self::HList {}
+}
+
+macro_rules! Product {
+    () => { () };
+    ($head:ident $(,$tail:ident)* $(,)?) => {
+        HCons<$head, Product!($($tail),*)>
+    };
+}
+
+macro_rules! product_pat {
+    () => { () };
+    ($head:ident $(,$tail:ident)* $(,)?) => {
+        HCons {
+            head: $head, 
+            tail: product_pat!($($tail),*)
+        }
+    };
+}
+
+macro_rules! impl_tuple {
+    ($head:ident $(,$tail:ident)* $(,)?) => {
+        impl<$head $(,$tail)*> Tuple for ($head, $($tail),*) {
+            type HList = HCons<$head, <($($tail,)*) as Tuple>::HList>;
+
+            #[inline]
+            fn hlist(self) -> Self::HList {
+                #[allow(non_snake_case)]
+                let ($head, $($tail),*) = self;
+                HCons {
+                    head: $head,
+                    tail: ($($tail,)*).hlist(),
+                }
+            }
+        }
+
+        impl<$head $(,$tail)*> HList for Product!($head $(,$tail)*) {
+            type Tuple = ($head, $($tail),*);
+
+            #[inline]
+            fn flatten(self) -> Self::Tuple {
+                #[allow(non_snake_case)]
+                let product_pat!($head, $($tail),*) = self;
+                ($head, $($tail),*)
+            }
+        }
+    };
+}
+
+macro_rules! smaller_tuples_too {
+    ($macro:ident, $head:ident $(,)?) => {
+        $macro!($head);
+    };
+    ($macro:ident, $head:ident, $($tail:ident),* $(,)?) => {
+        $macro!($head, $($tail),*);
+        smaller_tuples_too!($macro, $($tail),*);
+    };
+}
+
+smaller_tuples_too!(
+    impl_tuple, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18,
+    T19, T20
+);
+
+
+pub trait Plucker<Target, Index> {
+    type Remainder;
+
+    fn pluck(self) -> (Target, Self::Remainder);
+}
+
+pub trait PluckerRef<Target, Index> {
+    fn pluck(&self) -> &Target;
+}
+
+pub trait PluckerRefMut<Target, Index> {
+    fn pluck(&mut self) -> &mut Target;
+}
+
+struct Here {}
+
+impl<Target, Tail> Plucker<Target, Here> for HCons<Target, Tail> {
+    type Remainder = Tail;
+
+    #[inline]
+    fn pluck(self) -> (Target, Self::Remainder) {
+        (self.head, self.tail)
+    }
+}
+
+impl<Target, Tail> PluckerRef<Target, Here> for HCons<Target, Tail> {
+    #[inline]
+    fn pluck(&self) -> &Target {
+        &self.head
+    }
+}
+
+impl<Target, Tail> PluckerRefMut<Target, Here> for HCons<Target, Tail> {
+    #[inline]
+    fn pluck(&mut self) -> &mut Target {
+        &mut self.head
+    }
+}
+
+struct There<T>(PhantomData<T>);
+
+impl<Target, Head, Tail, TailIndex> Plucker<Target, There<TailIndex>> for HCons<Head, Tail>
+where
+    Tail: Plucker<Target, TailIndex>,
+{
+    type Remainder = HCons<Head, <Tail as Plucker<Target, TailIndex>>::Remainder>;
+
+    #[inline]
+    fn pluck(self) -> (Target, Self::Remainder) {
+        let (target, tail_remainder): (Target, <Tail as Plucker<Target, TailIndex>>::Remainder) =
+            <Tail as Plucker<Target, TailIndex>>::pluck(self.tail);
+        (
+            target,
+            HCons {
+                head: self.head,
+                tail: tail_remainder,
+            },
+        )
+    }
+}
+
+impl<Target, Head, Tail, TailIndex> PluckerRef<Target, There<TailIndex>> for HCons<Head, Tail>
+where
+    Tail: PluckerRef<Target, TailIndex>,
+{
+    #[inline]
+    fn pluck(&self) -> &Target {
+        <Tail as PluckerRef<Target, TailIndex>>::pluck(&self.tail)
+    }
+}
+
+impl<Target, Head, Tail, TailIndex> PluckerRefMut<Target, There<TailIndex>> for HCons<Head, Tail>
+where
+    Tail: PluckerRefMut<Target, TailIndex>,
+{
+    #[inline]
+    fn pluck(&mut self) -> &mut Target {
+        <Tail as PluckerRefMut<Target, TailIndex>>::pluck(&mut self.tail)
+    }
+}

--- a/quill/api/src/lib.rs
+++ b/quill/api/src/lib.rs
@@ -4,10 +4,10 @@ pub mod entities;
 mod entity;
 mod entity_builder;
 mod game;
-pub mod query;
 pub mod hlist;
-mod setup;
+pub mod query;
 pub mod send_message;
+mod setup;
 
 pub use entity::{Entity, EntityId};
 pub use entity_builder::EntityBuilder;

--- a/quill/api/src/lib.rs
+++ b/quill/api/src/lib.rs
@@ -7,7 +7,7 @@ mod game;
 pub mod query;
 pub mod hlist;
 mod setup;
-mod send_message;
+pub mod send_message;
 
 pub use entity::{Entity, EntityId};
 pub use entity_builder::EntityBuilder;

--- a/quill/api/src/lib.rs
+++ b/quill/api/src/lib.rs
@@ -5,11 +5,14 @@ mod entity;
 mod entity_builder;
 mod game;
 pub mod query;
+pub mod hlist;
 mod setup;
+mod send_message;
 
 pub use entity::{Entity, EntityId};
 pub use entity_builder::EntityBuilder;
 pub use game::Game;
+pub use hlist::*;
 pub use setup::Setup;
 
 #[doc(inline)]

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -11,8 +11,8 @@ where
     T: TupleRef<'a>,
     <T as TupleRef<'a>>::HList: PluckerRef<Player, Index>,
 {
-    fn send_message(&'a self, message: &str) {
+    fn send_message(&'a self, _message: &str) {
         let foo = self.1.hlist();
-        let player = PluckerRef::<Player, Index>::pluck(&foo);
+        let _player: &Player = PluckerRef::<Player, Index>::pluck(&foo);
     }
 }

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -1,6 +1,6 @@
 use quill_common::entities::Player;
 
-use crate::{Entity, Plucker, PluckerRef, Tuple};
+use crate::{Entity, Plucker, Tuple};
 
 pub trait SendMessage<Index> {
     fn send_message(&self, message: &str);
@@ -9,11 +9,10 @@ pub trait SendMessage<Index> {
 impl<T, Index> SendMessage<Index> for (Entity, T)
 where
     T: Tuple,
-    <T as Tuple>::HList: PluckerRef<Player, Index>
+    <T as Tuple>::HList: Plucker<Ref<Player>, Index>
 {
     fn send_message(&self, message: &str) {
         let components = &self.1;
-        let foo = components.hlist();
-        let player = PluckerRef::<Player, Index>::pluck(components.hlist());
+        let player = Plucker::<Player, Index>::pluck(&components.hlist());
     }
 }

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -1,0 +1,19 @@
+use quill_common::entities::Player;
+
+use crate::{Entity, Plucker, PluckerRef, Tuple};
+
+pub trait SendMessage<Index> {
+    fn send_message(&self, message: &str);
+}
+
+impl<T, Index> SendMessage<Index> for (Entity, T)
+where
+    T: Tuple,
+    <T as Tuple>::HList: PluckerRef<Player, Index>
+{
+    fn send_message(&self, message: &str) {
+        let components = &self.1;
+        let foo = components.hlist();
+        let player = PluckerRef::<Player, Index>::pluck(components.hlist());
+    }
+}

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -6,10 +6,10 @@ pub trait SendMessage<'a, Index> {
     fn send_message(&'a self, message: &str);
 }
 
-impl<'a, T, Index> SendMessage<'a, Index> for (&'a Entity, &'a T)
+impl<'a, T, Index> SendMessage<'a, Index> for (&'a Entity, T)
 where
-    &'a T: TupleRef<'a>,
-    <&'a T as TupleRef<'a>>::HList: PluckerRef<Player, Index>
+    T: TupleRef<'a>,
+    <T as TupleRef<'a>>::HList: PluckerRef<Player, Index>
 {
     fn send_message(&'a self, message: &str) {
         let foo = self.1.hlist();

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -1,18 +1,18 @@
 use quill_common::entities::Player;
 
-use crate::{Entity, Plucker, Tuple};
+use crate::{Entity, PluckerRef, TupleRef};
 
-pub trait SendMessage<Index> {
-    fn send_message(&self, message: &str);
+pub trait SendMessage<'a, Index> {
+    fn send_message(&'a self, message: &str);
 }
 
-impl<T, Index> SendMessage<Index> for (Entity, T)
+impl<'a, T, Index> SendMessage<'a, Index> for (&'a Entity, &'a T)
 where
-    T: Tuple,
-    <T as Tuple>::HList: Plucker<Player, Index>
+    &'a T: TupleRef<'a>,
+    <&'a T as TupleRef<'a>>::HList: PluckerRef<Player, Index>
 {
-    fn send_message(&self, message: &str) {
-        let components = &self.1;
-        let player = Plucker::<Player, Index>::pluck(&components.hlist());
+    fn send_message(&'a self, message: &str) {
+        let foo = self.1.hlist();
+        let player = PluckerRef::<Player, Index>::pluck(&foo);
     }
 }

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -9,7 +9,7 @@ pub trait SendMessage<Index> {
 impl<T, Index> SendMessage<Index> for (Entity, T)
 where
     T: Tuple,
-    <T as Tuple>::HList: Plucker<Ref<Player>, Index>
+    <T as Tuple>::HList: Plucker<Player, Index>
 {
     fn send_message(&self, message: &str) {
         let components = &self.1;

--- a/quill/api/src/send_message.rs
+++ b/quill/api/src/send_message.rs
@@ -9,7 +9,7 @@ pub trait SendMessage<'a, Index> {
 impl<'a, T, Index> SendMessage<'a, Index> for (&'a Entity, T)
 where
     T: TupleRef<'a>,
-    <T as TupleRef<'a>>::HList: PluckerRef<Player, Index>
+    <T as TupleRef<'a>>::HList: PluckerRef<Player, Index>,
 {
     fn send_message(&'a self, message: &str) {
         let foo = self.1.hlist();

--- a/quill/example-plugins/block-place/src/lib.rs
+++ b/quill/example-plugins/block-place/src/lib.rs
@@ -16,7 +16,7 @@ impl Plugin for BlockPlace {
 }
 
 fn system(_plugin: &mut BlockPlace, game: &mut Game) {
-    for (_entity, _event) in game.query::<&BlockPlacementEvent>() {
+    for (_entity, _event) in game.query::<(&BlockPlacementEvent,)>() {
         println!("A client has placed a block!");
     }
 }

--- a/quill/example-plugins/query-entities/src/lib.rs
+++ b/quill/example-plugins/query-entities/src/lib.rs
@@ -1,7 +1,7 @@
 //! An example plugin that spawns 10,000 entities
 //! on startup, then moves them each tick using a query.
 
-use quill::{EntityInit, Game, Plugin, Position, Tuple, TupleRef, entities::{PiglinBrute, Player}, send_message::SendMessage};
+use quill::{EntityInit, Game, Plugin, Position, entities::{PiglinBrute, Player}, send_message::SendMessage};
 use rand::Rng;
 
 quill::plugin!(QueryEntities);
@@ -49,8 +49,7 @@ fn query_system(plugin: &mut QueryEntities, game: &mut Game) {
     }
  
     for (entity, (player,)) in game.query::<(&Player,)>() {
-        TupleRef::hlist(&(&player,));
-        (&entity, &(&player,)).send_message("Hello world!");
-        // (&player).send_message("Hello world!");
+        (&entity, (&player,)).send_message("Hello world!");
+        (&entity, (&player,)).send_message("Hello world!");        
     }
 }

--- a/quill/example-plugins/query-entities/src/lib.rs
+++ b/quill/example-plugins/query-entities/src/lib.rs
@@ -1,7 +1,11 @@
 //! An example plugin that spawns 10,000 entities
 //! on startup, then moves them each tick using a query.
 
-use quill::{EntityInit, Game, Plugin, Position, entities::{PiglinBrute, Player}, send_message::SendMessage};
+use quill::{
+    entities::{PiglinBrute, Player},
+    send_message::SendMessage,
+    EntityInit, Game, Plugin, Position,
+};
 use rand::Rng;
 
 quill::plugin!(QueryEntities);
@@ -47,9 +51,9 @@ fn query_system(plugin: &mut QueryEntities, game: &mut Game) {
             ..position
         });
     }
- 
+
     for (entity, (player,)) in game.query::<(&Player,)>() {
         (&entity, (&player,)).send_message("Hello world!");
-        (&entity, (&player,)).send_message("Hello world!");        
+        (&entity, (&player,)).send_message("Hello world!");
     }
 }

--- a/quill/example-plugins/query-entities/src/lib.rs
+++ b/quill/example-plugins/query-entities/src/lib.rs
@@ -1,7 +1,7 @@
 //! An example plugin that spawns 10,000 entities
 //! on startup, then moves them each tick using a query.
 
-use quill::{entities::PiglinBrute, EntityInit, Game, Plugin, Position};
+use quill::{EntityInit, Game, Plugin, Position, Tuple, TupleRef, entities::{PiglinBrute, Player}, send_message::SendMessage};
 use rand::Rng;
 
 quill::plugin!(QueryEntities);
@@ -46,5 +46,11 @@ fn query_system(plugin: &mut QueryEntities, game: &mut Game) {
             y: position.y + 0.1 * ((plugin.tick_counter as f64 / 20.0).sin() + 1.0),
             ..position
         });
+    }
+ 
+    for (entity, (player,)) in game.query::<(&Player,)>() {
+        TupleRef::hlist(&(&player,));
+        (&entity, &(&player,)).send_message("Hello world!");
+        // (&player).send_message("Hello world!");
     }
 }


### PR DESCRIPTION
```rust
pub trait SendMessage<'a, Index> {
    fn send_message(&'a self, message: &str);
}

impl<'a, T, Index> SendMessage<'a, Index> for (&'a Entity, T)
where
    T: TupleRef<'a>,
    <T as TupleRef<'a>>::HList: PluckerRef<Player, Index>,
{
    fn send_message(&'a self, _message: &str) {
        let _player: &Player = PluckerRef::<Player, Index>::pluck(&foo);
    }
}

for (entity, (player,)) in game.query::<(&Player,)>() {
      (&entity, (&player,)).send_message("Hello world!");
      (&entity, (&player,)).send_message("Hello world!");
}
```

It's still missing support for mutable references and in addition it might also be possible to change the signature a such that `&(Entity, (Player,))` also works.