### PR TITLE
Add discord logo to "chat" badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Feather
 [![build](https://github.com/feather-rs/feather/workflows/build/badge.svg)](https://github.com/feather-rs/feather/actions)
-[![Discord](https://img.shields.io/discord/619316022800809995)](https://discordapp.com/invite/4eYmK69)
+[![Discord](https://img.shields.io/discord/619316022800809995?logo=discord)](https://discordapp.com/invite/4eYmK69)
 
 A Minecraft server implementation written in Rust.
 


### PR DESCRIPTION
So that anyone knows what "chat" is meant without having to click on the badge or hover over it to look at the link.