### PR TITLE
Commands, they said it would be a good first issue. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
 
 [[package]]
 name = "approx"
@@ -241,9 +241,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a2e31dce162f8f238c3c35a6600f1df4cb30f8929a6c464b0a8118d17c2502"
+checksum = "d23f76a953a42e113af6b4f3481ca32ff0a1ddbdcaa714a2333c956807b74a5f"
 dependencies = [
  "funty",
  "radium",
@@ -474,6 +474,14 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "command"
+version = "0.1.0"
+dependencies = [
+ "lieutenant",
+ "quill",
 ]
 
 [[package]]
@@ -720,6 +728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +841,7 @@ dependencies = [
  "flume",
  "itertools 0.10.0",
  "libcraft-core",
+ "lieutenant",
  "log",
  "parking_lot",
  "quill-common",
@@ -882,8 +901,9 @@ dependencies = [
  "feather-ecs",
  "feather-plugin-host-macros",
  "libloading 0.7.0",
+ "lieutenant",
  "log",
- "paste 1.0.4",
+ "paste 1.0.5",
  "quill-common",
  "quill-plugin-format",
  "serde",
@@ -947,7 +967,7 @@ dependencies = [
  "libcraft-core",
  "log",
  "md-5",
- "num-bigint 0.3.1",
+ "num-bigint 0.3.2",
  "once_cell",
  "parking_lot",
  "quill-common",
@@ -1239,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -1331,9 +1351,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1368,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "ba4aede83fc3617411dc6993bc8c70919750c1c257c6ca6a502aed6e0e2394ae"
 
 [[package]]
 name = "libcraft-blocks"
@@ -1498,6 +1518,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "lieutenant"
+version = "0.1.0"
+source = "git+https://github.com/Miro-Andrin/lieutenant.git?branch=new-new-command-builder#e7f74eaa32fb574e0a0d12f57de025460809be7a"
+dependencies = [
+ "anyhow",
+ "fnv",
+ "indexmap",
+ "lazy_static",
+ "quickcheck",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "llvm-sys"
 version = "110.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
 dependencies = [
  "libc",
  "log",
@@ -1628,7 +1662,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -1649,12 +1683,12 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670361df1bc2399ee1ff50406a0d422587dd3bb0da596e1978fe8e05dabddf4f"
+checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
 dependencies = [
  "libc",
- "socket2",
+ "socket2 0.4.0",
 ]
 
 [[package]]
@@ -1701,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -1870,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "paste-impl"
@@ -1931,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cf491442e4b033ed1c722cb9f0df5fcfcf4de682466c46469c36bc47dc5548a"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pkg-config"
@@ -1962,11 +1996,11 @@ checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
 name = "polling"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+checksum = "4fc12d774e799ee9ebae13f4076ca003b40d18a11ac0f3641e6f899618580b7b"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-sys",
@@ -2036,6 +2070,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.3",
+]
+
+[[package]]
 name = "quill"
 version = "0.1.0"
 dependencies = [
@@ -2045,6 +2090,7 @@ dependencies = [
  "libcraft-core",
  "libcraft-particles",
  "libcraft-text",
+ "lieutenant",
  "quill-common",
  "quill-sys",
  "thiserror",
@@ -2257,21 +2303,20 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "region"
@@ -2452,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -2470,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2492,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38145a8510bdf71d9a8cceeb57664049538446e77f24648328bdbcf22dc7e169"
+checksum = "61c59238fc0762e8aee0c6ec5f1a2e61d580d94f6274b9fcc91dc51d03fb40ba"
 dependencies = [
  "serde",
 ]
@@ -2634,6 +2679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,9 +2763,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2787,15 +2842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "134af885d758d645f0f0505c9a8b3f9bf8a348fd822e112ab5248138348f1722"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -2890,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2910,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "typetag"
@@ -3045,9 +3091,9 @@ checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec-arena"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+checksum = "34b2f665b594b07095e3ac3f718e13c2197143416fae4c5706cffb7b1af8d7f1"
 
 [[package]]
 name = "vek"
@@ -3065,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "waker-fn"
@@ -3089,9 +3135,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3099,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3114,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3124,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3137,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "wasmer"
@@ -3367,9 +3413,9 @@ checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "quill/example-plugins/plugin-message",
     "quill/example-plugins/query-entities",
     "quill/example-plugins/simple",
+    "quill/example-plugins/command",
 
     # Feather (common and server)
     "feather/utils",

--- a/feather/common/Cargo.toml
+++ b/feather/common/Cargo.toml
@@ -20,3 +20,4 @@ smartstring = "0.2"
 utils = { path = "../utils", package = "feather-utils" }
 uuid = { version = "0.8", features = [ "v4" ] }
 libcraft-core = { path = "../../libcraft/core" }
+lieutenant = { git = "https://github.com/Miro-Andrin/lieutenant.git", branch = "new-new-command-builder" }

--- a/feather/old/definitions/generator/src/frontend.rs
+++ b/feather/old/definitions/generator/src/frontend.rs
@@ -87,7 +87,7 @@ impl<'a, 'b> Query<'a> for CompileEnum<'b> {
 
         let (name, variants) = match model {
             Model::Enum { variants, name } => (*name, variants.as_slice()),
-            _ => unreachable!(),
+            _ => unreachable!("model not there"),
         };
 
         let mut actual_variants = vec![];

--- a/feather/old/server/physics/src/math.rs
+++ b/feather/old/server/physics/src/math.rs
@@ -394,13 +394,13 @@ pub fn adjacent_to_bbox(
         0 => 1,
         1 => 2,
         2 => 0,
-        _ => unreachable!(),
+        _ => unreachable!("Assertion should have triggerd"),
     };
     let other_axis2 = match axis {
         0 => 2,
         1 => 0,
         2 => 1,
-        _ => unreachable!(),
+        _ => unreachable!("Assertion should have triggerd"),
     };
 
     let offsets = {

--- a/feather/plugin-host/Cargo.toml
+++ b/feather/plugin-host/Cargo.toml
@@ -25,6 +25,7 @@ tempfile = "3"
 vec-arena = "1"
 wasmer = { version = "1", default-features = false, features = [ "jit" ] }
 wasmer-wasi = { version = "1", default-features = false }
+lieutenant = { git = "https://github.com/Miro-Andrin/lieutenant.git", branch = "new-new-command-builder" }
 
 [features]
 llvm = [ "wasmer/llvm" ]

--- a/feather/plugin-host/src/command_dispatcher.rs
+++ b/feather/plugin-host/src/command_dispatcher.rs
@@ -1,0 +1,151 @@
+use std::{
+    cell::RefCell,
+    convert::TryInto,
+    fmt::{self, Debug},
+    rc::Rc,
+};
+
+use anyhow::bail;
+use feather_ecs::{Entity, EntityRef};
+use lieutenant::regex::early_termination::CmdPos;
+use lieutenant::regex::{dfa::DFA, NFA};
+use crate::{context::PluginPtrMut, Game, PluginId, PluginManager};
+
+// Constant that should reflect how many commands a default
+// server starts with. Vanilla has roughly 60
+const NUM_COMMANDS: usize = 20;
+
+type CommandId = u32;
+
+/// A collection of data containing what plugin a command was defined in, 
+/// the pointer to its Box<Command<...>>, and the regex that determines 
+/// when the command should be called.(The command does some parsing beyond the regex).
+pub struct CommandDescription {
+    pub plugin_id: PluginId,
+    pub regex: String,
+    // Should only come from host_call register_system.
+    // it is a pointer to a Box<dyn Command<GameState=(Plugin,CommandContext),z CommandResult=i64>>
+    pub callback: PluginPtrMut<u8>,
+}
+
+impl CommandDescription {
+    // Returns true or false depending on if the command executed or not.
+    // If it returns false that means the commands parser did not recognize
+    // the commnd.
+    fn call(&self, game: &mut Game, input: &str) -> anyhow::Result<()> {
+        let plugin_manager = Rc::clone(&*game.resources.get::<Rc<RefCell<PluginManager>>>()?);
+        let plugin_manager = plugin_manager.borrow();
+        let plugin = plugin_manager.plugin(self.plugin_id);
+
+        match plugin {
+            Some(plugin) => {
+                plugin.call_command(game, input, self.callback)?;
+                Ok(())
+            }
+            None => {
+                // Plugin has been unloaded.
+                bail!("Plugin was unloaded.")
+            }
+        }
+    }
+}
+
+pub struct CommandDispatcher {
+    dfa: DFA<CmdPos<CommandId>>,
+    commands: Vec<CommandDescription>,
+}
+
+impl fmt::Debug for CommandDispatcher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.dfa.fmt(f)
+    }
+}
+
+impl CommandDispatcher {
+    pub fn new() -> Self {
+        Self {
+            dfa: DFA::new(),
+            commands: Vec::with_capacity(NUM_COMMANDS),
+        }
+    }
+
+    /// Adds a command. Should be followed by update update dfa.
+    pub fn add_command(&mut self, cmd: CommandDescription) {
+        self.commands.push(cmd);
+        // This method should not be called for every command we
+        // add. It is somewhat expensive. It is O(n) in the number of
+        // commands we have registerd so far. Therefor adding m commands
+        // is a O(m^2) operation. 
+        // Instead we should (option a) try to build only the dfa for the 
+        // single cmd (to check that its regex does not use any unimplemented features)
+        /// by calling  NFA::<CmdPos<CommandId>>::from_command_regex(&cmd.regex,0).is_ok();
+        /// or (option b) add a method to lieutenants NFA that checks if the regex
+        /// contains any unimplemented features. See lieutenant/regex/regex_to_nfa, and 
+        /// call that method instead. Anyways for these options we need someway of triggering
+        /// dfa updates. Could probably happen inside plugin load function, in main, or a host-call.
+        self.update_dfa();
+    }
+
+    // Can fail if we run out of u32 ids for the nodes in the nfa graph. This should be unlikely.
+    pub fn update_dfa(&mut self) -> anyhow::Result<()> {
+        let mut nfa = NFA::<CmdPos<CommandId>>::empty();
+
+        for (id, cmd) in self.commands.iter().enumerate() {
+            let cmd_nfa = NFA::<CmdPos<CommandId>>::from_command_regex(
+                &cmd.regex,
+                id.try_into()
+                    .expect("Cant register 2^32 different commands!"),
+            )?;
+            nfa = nfa.or(cmd_nfa)?;
+        }
+        // Reduses the number of states/nodes, so it cant fail.
+        self.dfa = nfa.into_early_termination_dfa();
+        Ok(())
+    }
+
+    /// calls the corresponding command (if it exists) and returns the resulting u32
+    /// player is person calling the command, None means terminal.
+    pub fn call(
+        &self,
+        game: &mut Game,
+        input: &str,
+        player: Option<Entity>,
+    ) -> anyhow::Result<i64> {
+        match self.dfa.early_termination_find(input) {
+            Ok(ids) => {
+                for id in ids {
+                    let description = &self.commands[id as usize];
+
+                    let plugin_manager =
+                        Rc::clone(&*game.resources.get::<Rc<RefCell<PluginManager>>>()?);
+                    let plugin_manager = plugin_manager.borrow();
+                    let plugin = plugin_manager.plugin(description.plugin_id);
+
+                    match plugin {
+                        Some(plugin) => {
+                            match plugin.call_command(game, input, description.callback.clone()) {
+                                Ok(x) => {
+                                    return Ok(x);
+                                }
+                                Err(_) => {
+                                    // Was not able to call command, probably due to failed parsing.
+                                    // (unless there is some failure case i have not considerd), or someone
+                                    // is not using lieutenant, but their own shenanigans.
+                                    continue;
+                                }
+                            }
+                        }
+
+                        None => {
+                            // Plugin has been unloaded.
+                            continue;
+                        }
+                    }
+                }
+            }
+            Err(ids) => {}
+        }
+
+        bail!("Failed to find a command that matched the input")
+    }
+}

--- a/feather/plugin-host/src/host_calls.rs
+++ b/feather/plugin-host/src/host_calls.rs
@@ -9,6 +9,7 @@ use crate::env::PluginEnv;
 use crate::host_function::{NativeHostFunction, WasmHostFunction};
 
 mod block;
+mod command;
 mod component;
 mod entity;
 mod entity_builder;
@@ -46,6 +47,7 @@ macro_rules! host_calls {
 }
 
 use block::*;
+use command::*;
 use component::*;
 use entity::*;
 use entity_builder::*;
@@ -69,4 +71,5 @@ host_calls! {
     "block_set" => block_set,
     "block_fill_chunk_section" => block_fill_chunk_section,
     "plugin_message_send" => plugin_message_send,
+    "register_command" => register_command,
 }

--- a/feather/plugin-host/src/host_calls/command.rs
+++ b/feather/plugin-host/src/host_calls/command.rs
@@ -1,0 +1,32 @@
+use std::{borrow::BorrowMut, cell::RefCell, rc::Rc};
+
+use feather_base::{BlockId, BlockPosition, ChunkPosition};
+use feather_plugin_host_macros::host_function;
+use quill_common::block::BlockGetResult;
+use wasmer_wasi::types::print_right_set;
+
+use crate::command_dispatcher::{CommandDescription, CommandDispatcher};
+use crate::context::{PluginContext, PluginPtr, PluginPtrMut};
+
+#[host_function]
+pub fn register_command(
+    cx: &PluginContext,
+    regex: PluginPtr<u8>,
+    regex_len: u32,
+    command: PluginPtrMut<u8>,
+) -> anyhow::Result<u32> {
+    let dispatcher = Rc::clone(
+        &*cx.game_mut()
+            .resources
+            .get::<Rc<RefCell<CommandDispatcher>>>()?,
+    );
+    let mut dispatcher = (*dispatcher).borrow_mut();
+
+    let description = CommandDescription {
+        plugin_id: cx.plugin_id(),
+        regex: cx.read_string(regex, regex_len)?,
+        callback: command,
+    };
+    dispatcher.add_command(description);
+    Ok(true as u32)
+}

--- a/feather/plugin-host/src/lib.rs
+++ b/feather/plugin-host/src/lib.rs
@@ -24,6 +24,7 @@ use wasmer::{
 };
 use wasmer_wasi::{WasiEnv, WasiState, WasiVersion};
 
+pub mod command_dispatcher;
 mod context;
 mod env;
 mod host_calls;
@@ -31,6 +32,8 @@ mod host_function;
 mod plugin;
 mod thread_pinned;
 mod wasm_ptr_ext;
+
+pub use command_dispatcher::CommandDispatcher;
 
 /// Features enabled for WASM plugins
 const WASM_FEATURES: Features = Features {

--- a/feather/plugin-host/src/plugin.rs
+++ b/feather/plugin-host/src/plugin.rs
@@ -116,7 +116,6 @@ impl Plugin {
             let context = Arc::clone(&self.context);
 
             // Allocate space inside the plugin memmory and copy over the command input
-            // @TODO mention this as a potential error case.
             let input_len: u32 = input.len().try_into()?;
             let input_ptr = context.bump_allocate_and_write_bytes(input.as_bytes())?;
 

--- a/feather/plugin-host/src/plugin.rs
+++ b/feather/plugin-host/src/plugin.rs
@@ -116,6 +116,7 @@ impl Plugin {
             let context = Arc::clone(&self.context);
 
             // Allocate space inside the plugin memmory and copy over the command input
+            // @TODO mention this as a potential error case.
             let input_len: u32 = input.len().try_into()?;
             let input_ptr = context.bump_allocate_and_write_bytes(input.as_bytes())?;
 

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -67,7 +67,7 @@ fn init_world_source(game: &mut Game) {
     game.world = World::with_source(world_source);
 }
 
-fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()>   {
+fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()> {
     let mut plugin_manager = PluginManager::new();
     plugin_manager.load_dir(game, PLUGINS_DIRECTORY)?;
 
@@ -76,7 +76,7 @@ fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()>   {
     Ok(())
 }
 
-/// Sets up game resource for handeling dispatching 
+/// Sets up game resource for handeling dispatching
 /// commands like '/msg @p ...' to the respective
 /// plugins. Has to be loaded before init_plugin_manager.
 fn init_command_disptcher(game: &mut Game) {

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -38,7 +38,7 @@ fn init_game(server: Server) -> anyhow::Result<Game> {
     let mut game = Game::new();
     init_systems(&mut game, server);
     init_world_source(&mut game);
-    init_command_disptcher(&mut game)?;
+    init_command_disptcher(&mut game);
     init_plugin_manager(&mut game)?;
     Ok(game)
 }
@@ -67,7 +67,7 @@ fn init_world_source(game: &mut Game) {
     game.world = World::with_source(world_source);
 }
 
-fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()> {
+fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()>   {
     let mut plugin_manager = PluginManager::new();
     plugin_manager.load_dir(game, PLUGINS_DIRECTORY)?;
 
@@ -76,13 +76,13 @@ fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Sets up game resource for handeling dispatching commands like '/msg @p ...'
-/// to the respective plugins.
-fn init_command_disptcher(game: &mut Game) -> anyhow::Result<()> {
+/// Sets up game resource for handeling dispatching 
+/// commands like '/msg @p ...' to the respective
+/// plugins. Has to be loaded before init_plugin_manager.
+fn init_command_disptcher(game: &mut Game) {
     let cmd_d = CommandDispatcher::new();
     let rc = Rc::new(RefCell::new(cmd_d));
     game.insert_resource(rc);
-    Ok(())
 }
 
 fn print_systems(systems: &SystemExecutor<Game>) {

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -7,6 +7,7 @@ use common::{
 };
 use ecs::SystemExecutor;
 use feather_server::Server;
+use plugin_host::CommandDispatcher;
 use plugin_host::PluginManager;
 
 mod logging;
@@ -37,6 +38,7 @@ fn init_game(server: Server) -> anyhow::Result<Game> {
     let mut game = Game::new();
     init_systems(&mut game, server);
     init_world_source(&mut game);
+    init_command_disptcher(&mut game)?;
     init_plugin_manager(&mut game)?;
     Ok(game)
 }
@@ -71,6 +73,15 @@ fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()> {
 
     let plugin_manager_rc = Rc::new(RefCell::new(plugin_manager));
     game.insert_resource(plugin_manager_rc);
+    Ok(())
+}
+
+/// Sets up game resource for handeling dispatching commands like '/msg @p ...'
+/// to the respective plugins.
+fn init_command_disptcher(game: &mut Game) -> anyhow::Result<()> {
+    let cmd_d = CommandDispatcher::new();
+    let rc = Rc::new(RefCell::new(cmd_d));
+    game.insert_resource(rc);
     Ok(())
 }
 

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -152,7 +152,6 @@ fn handle_chat_message(
         Ok(res) => {
             //TODO figure out what to do with the result
             println!("Result from running command was: {}", res);
-
         }
     }
 

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -150,8 +150,9 @@ fn handle_chat_message(
             game.broadcast_chat(ChatKind::PlayerChat, message);
         }
         Ok(res) => {
-            //@TODO
-            println!("Result was: {}", res);
+            //TODO figure out what to do with the result
+            println!("Result from running command was: {}", res);
+
         }
     }
 

--- a/quill/api/Cargo.toml
+++ b/quill/api/Cargo.toml
@@ -15,4 +15,5 @@ quill-sys = { path = "../sys" }
 quill-common = { path = "../common" }
 thiserror = "1"
 uuid = "0.8"
+lieutenant = { git = "https://github.com/Miro-Andrin/lieutenant.git", branch = "new-new-command-builder" }
 

--- a/quill/api/src/command.rs
+++ b/quill/api/src/command.rs
@@ -3,12 +3,24 @@ This file contains defenitions used for quills/feathers command dispatching/call
 A command is something like "/msg KillerBunny You stole my name!"
 */
 
-use crate::{EntityId, Game};
+use crate::Entity;
+use crate::Game;
+use quill_common::EntityId;
 
 pub enum Caller {
-    Player(EntityId),
+    Player(Entity),
     Terminal,
 }
+
+impl From<Option<EntityId>> for Caller {
+    fn from(it: Option<EntityId>) -> Self {
+        match it {
+            Some(id) => Caller::Player(Entity::new(crate::EntityId(id))),
+            None => Caller::Terminal,
+        }
+    }
+}
+
 /// This is what is passed into the command when its called.
 pub struct CommandContext {
     pub game: Game,

--- a/quill/api/src/command.rs
+++ b/quill/api/src/command.rs
@@ -1,0 +1,16 @@
+/*
+This file contains defenitions used for quills/feathers command dispatching/calling.
+A command is something like "/msg KillerBunny You stole my name!"
+*/
+
+use crate::{EntityId, Game};
+
+pub enum Caller {
+    Player(EntityId),
+    Terminal,
+}
+/// This is what is passed into the command when its called.
+pub struct CommandContext {
+    pub game: Game,
+    pub caller: Caller,
+}

--- a/quill/api/src/setup.rs
+++ b/quill/api/src/setup.rs
@@ -83,7 +83,7 @@ impl<Plugin: 'static> Setup<Plugin> {
 
         if !was_sucsess {
             // Figure out what to do if a command was not able to be added.
-            // TODO
+            // @TODO
         }
 
         self

--- a/quill/api/src/setup.rs
+++ b/quill/api/src/setup.rs
@@ -82,7 +82,7 @@ impl<Plugin: 'static> Setup<Plugin> {
 
         if !was_sucsess {
             // TODO Figure out what to do if a command was not able to be added.
-            panic!("Not able to add command, with regex: {}",regex);
+            panic!("Not able to add command, with regex: {}", regex);
         }
 
         self

--- a/quill/api/src/setup.rs
+++ b/quill/api/src/setup.rs
@@ -55,8 +55,7 @@ impl<Plugin: 'static> Setup<Plugin> {
     /// then you should be fine.
     ///
     /// If you need to listen in on all chat msg's then
-    /// you should ... @TODO give alternative.
-    //pub fn add_command<P, T: FnMut(&mut CommandContext<P>, &str) -> u32>(
+    /// you should ... TODO give alternative.
     pub fn add_command<
         'a,
         C: Command<GameState = (&'a mut Plugin, &'a mut CommandContext), CommandResult = i64>,
@@ -85,7 +84,7 @@ impl<Plugin: 'static> Setup<Plugin> {
             // TODO Figure out what to do if a command was not able to be added.
             panic!("Not able to add command, with regex: {}",regex);
         }
-        
+
         self
     }
 }

--- a/quill/api/src/setup.rs
+++ b/quill/api/src/setup.rs
@@ -82,10 +82,10 @@ impl<Plugin: 'static> Setup<Plugin> {
         };
 
         if !was_sucsess {
-            // Figure out what to do if a command was not able to be added.
-            // @TODO
+            // TODO Figure out what to do if a command was not able to be added.
+            panic!("Not able to add command, with regex: {}",regex);
         }
-
+        
         self
     }
 }

--- a/quill/api/src/setup.rs
+++ b/quill/api/src/setup.rs
@@ -1,6 +1,8 @@
-use std::marker::PhantomData;
+use std::{convert::TryInto, marker::PhantomData};
 
-use crate::Game;
+use lieutenant::command::command::Command;
+
+use crate::{command::CommandContext, Game};
 
 /// Struct passed to your plugin's `enable()` function.
 ///
@@ -9,7 +11,7 @@ pub struct Setup<Plugin> {
     _marker: PhantomData<Plugin>,
 }
 
-impl<Plugin> Setup<Plugin> {
+impl<Plugin: 'static> Setup<Plugin> {
     /// For Quill internal use only. Do not call.
     #[doc(hidden)]
     #[allow(clippy::clippy::new_without_default)]
@@ -32,6 +34,56 @@ impl<Plugin> Setup<Plugin> {
 
         unsafe {
             quill_sys::register_system(system_data.into(), name.as_ptr().into(), name.len() as u32);
+        }
+
+        self
+    }
+
+    /// Registers a command to be triggerd when
+    /// some chat msg roughly looks like the regex.
+    /// The server is very lazy when it comes to
+    /// command dispatching, so dont expect it to have
+    /// perfectly/compleatly matched the regex before
+    /// invoking the callback.
+    ///
+    /// You should not register a command with too borad
+    /// of a regex. So a regex "." or ".\s*" is bad.
+    /// It can prevent the server from optimising its
+    /// DFA, making all command dispatching take more
+    /// memmory and beeing slower. If you are using
+    /// lieutenant with its vanilla parsers/arguments
+    /// then you should be fine.
+    ///
+    /// If you need to listen in on all chat msg's then
+    /// you should ... @TODO give alternative.
+    //pub fn add_command<P, T: FnMut(&mut CommandContext<P>, &str) -> u32>(
+    pub fn add_command<
+        'a,
+        C: Command<GameState = (&'a mut Plugin, &'a mut CommandContext), CommandResult = i64>,
+    >(
+        &mut self,
+        command: C,
+    ) -> &mut Self {
+        let command: Box<
+            dyn Command<GameState = (&'a mut Plugin, &'a mut CommandContext), CommandResult = i64>,
+        > = Box::new(command);
+        let regex = command.regex();
+        let data = Box::leak(Box::new(command)) as *mut Box<_> as *mut u8;
+
+        let was_sucsess = unsafe {
+            quill_sys::register_command(
+                regex.as_str().as_ptr().into(),
+                regex
+                    .len()
+                    .try_into()
+                    .expect("Wow, the regex for the command was too big! (over 4gb, impressive)"),
+                data.into(),
+            )
+        };
+
+        if !was_sucsess {
+            // Figure out what to do if a command was not able to be added.
+            // TODO
         }
 
         self

--- a/quill/common/src/component.rs
+++ b/quill/common/src/component.rs
@@ -284,7 +284,7 @@ macro_rules! pod_component_impl {
             }
 
             fn to_bytes(&self, _target: &mut Vec<u8>) {
-                unreachable!()
+                unreachable!("to_bytes not implemented")
             }
 
             fn as_bytes(&self) -> &[u8] {
@@ -318,7 +318,7 @@ macro_rules! bincode_component_impl {
             }
 
             fn as_bytes(&self) -> &[u8] {
-                unreachable!()
+                unreachable!("as_bytes not implemented")
             }
 
             fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {

--- a/quill/example-plugins/command/Cargo.toml
+++ b/quill/example-plugins/command/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "command"
+version = "0.1.0"
+authors = ["miroad <miro.sveits@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+quill = { path = "../../api" }
+lieutenant = { git = "https://github.com/Miro-Andrin/lieutenant.git", branch = "new-new-command-builder" }

--- a/quill/example-plugins/command/src/lib.rs
+++ b/quill/example-plugins/command/src/lib.rs
@@ -1,0 +1,23 @@
+use lieutenant::command::builder::{literal, CommandBuilder};
+use quill::{components::Name, CommandContext, Game, Plugin, Setup};
+
+quill::plugin!(SimpleCommand);
+
+struct SimpleCommand;
+
+impl Plugin for SimpleCommand {
+    fn enable(_game: &mut Game, setup: &mut Setup<Self>) -> Self {
+        setup.add_command(literal("/echo").space().arg::<u32>().on_call(|x: u32| {
+            move |_plugin: &mut Self, ctx: &mut CommandContext| {
+                for (entity, name) in ctx.game.query::<&Name>() {
+                    entity.send_message(format!("Hi {} your number was {}", name, x));
+                }
+                42
+            }
+        }));
+
+        SimpleCommand
+    }
+
+    fn disable(self, _game: &mut Game) {}
+}

--- a/quill/example-plugins/command/src/lib.rs
+++ b/quill/example-plugins/command/src/lib.rs
@@ -9,9 +9,16 @@ impl Plugin for SimpleCommand {
     fn enable(_game: &mut Game, setup: &mut Setup<Self>) -> Self {
         setup.add_command(literal("/echo").space().arg::<u32>().on_call(|x: u32| {
             move |_plugin: &mut Self, ctx: &mut CommandContext| {
-                for (entity, name) in ctx.game.query::<&Name>() {
-                    entity.send_message(format!("Hi {} your number was {}", name, x));
+                match &ctx.caller {
+                    quill::Caller::Player(player) => {
+                        let name = player.get::<Name>().unwrap();
+                        player.send_message(format!("Hi {} your number was {}", name, x));
+                    }
+                    quill::Caller::Terminal => {
+                        println!("Hi terminal, the number was {}", x);
+                    }
                 }
+
                 42
             }
         }));

--- a/quill/sys/src/lib.rs
+++ b/quill/sys/src/lib.rs
@@ -174,4 +174,26 @@ extern "C" {
         data_ptr: Pointer<u8>,
         data_len: u32,
     );
+
+    ///  Sends a regex string to the server and a pointer
+    ///  to a Box<dyn Command<...>>. Returns 'true'/'false'
+    ///  depending on if addition was sucsessfull.
+    ///
+    ///  When some text matches* the regex, the server is
+    ///  going to call the command. The first command it
+    ///  finds that returns Ok it considerd to have parsed
+    ///  and rand the command sucsessfully. It then wont try to
+    ///  call any other matches.
+    ///
+    ///  The server is lazy when matching the regex. If you
+    ///  register a regex/command starting with a "/zombiemode"
+    ///  and you have the only regex starting with a /z, then
+    ///  the server might call your command if someone
+    ///  types something that matches "/z.*".
+    ///
+    ///  Don't register road regexes like ".*". It prevents
+    ///  us from beeing lazy, which makes command dispatching
+    ///  slower and also increases memmory usage.
+    pub fn register_command(regex: Pointer<u8>, regex_len: u32, command: PointerMut<u8>) -> bool;
+
 }


### PR DESCRIPTION
# Regex backed command dispatching.
## Status

- [ ] Ready
- [x] Development
- [ ] Hold

## Description
I added rudimentary command dispatching, with an example plugin in quill/example-plugins/command. The example shows how to create a command "/echo <u32>", that prints a message to the caller.

This pull request should not be accepted until my pull request to lieutenant has been accepted. Currently, it has my lieutenant branch/repo set as a dependency in Cargo.toml.

### Limitations:
1) It only works for chat messages at the moment, but it would not be difficult for someone (or maybe me) to add rudimentary console command dispatching.  #329.  We could also consider adding a way for plugins to call each other.

2) It only allows for adding commands, so if someone were to load and unload a plugin there would be some build-up of garbage  in the command dispatcher. I or someone else just needs to hook into when a plugin is unloaded, and then  update the list of commands in  the command dispatcher.

###  Improvements I am currently working on.
1) Better error message when command registration fails. I am currently looking into this, by adding some functionality in lieutenant to detect when there is a regex using unsupported features.  So instead of just panicking
with a "could not load command", it should give an example of the regex feature casing the error.

2) Basic Diagnostics. We can get some interesting diagnostics from the command dispatcher. To begin with  i would just like to know.
a) How many commands are loaded.
b) How much memory the DFA is using,
c) Number of commands that can't be distinguished based on their regex. 

## Related issues
 #329, #229

## Checklist
- [ x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)
