### PR TITLE
Make LengthPrefixedVec generic

### DIFF
--- a/feather/protocol/src/codec.rs
+++ b/feather/protocol/src/codec.rs
@@ -85,7 +85,11 @@ impl MinecraftCodec {
         Ok(())
     }
 
-    fn encode_compressed(&mut self, output: &mut Vec<u8>, threshold: CompressionThreshold) -> anyhow::Result<()> {
+    fn encode_compressed(
+        &mut self,
+        output: &mut Vec<u8>,
+        threshold: CompressionThreshold,
+    ) -> anyhow::Result<()> {
         let (data_length, data) = if self.staging_buf.len() >= threshold {
             self.data_compressed()
         } else {

--- a/feather/protocol/src/codec.rs
+++ b/feather/protocol/src/codec.rs
@@ -67,13 +67,13 @@ impl MinecraftCodec {
     }
 
     /// Writes a packet into the provided writer.
-    pub fn encode(&mut self, packet: &impl Writeable, output: &mut Vec<u8>) {
-        packet.write(&mut self.staging_buf, ProtocolVersion::V1_16_2);
+    pub fn encode(&mut self, packet: &impl Writeable, output: &mut Vec<u8>) -> anyhow::Result<()> {
+        packet.write(&mut self.staging_buf, ProtocolVersion::V1_16_2)?;
 
         if let Some(threshold) = self.compression {
-            self.encode_compressed(output, threshold);
+            self.encode_compressed(output, threshold)?;
         } else {
-            self.encode_uncompressed(output);
+            self.encode_uncompressed(output)?;
         }
 
         if let Some(cryptor) = &mut self.cryptor {
@@ -81,9 +81,11 @@ impl MinecraftCodec {
         }
 
         self.staging_buf.clear();
+
+        Ok(())
     }
 
-    fn encode_compressed(&mut self, output: &mut Vec<u8>, threshold: CompressionThreshold) {
+    fn encode_compressed(&mut self, output: &mut Vec<u8>, threshold: CompressionThreshold) -> anyhow::Result<()> {
         let (data_length, data) = if self.staging_buf.len() >= threshold {
             self.data_compressed()
         } else {
@@ -98,11 +100,13 @@ impl MinecraftCodec {
             .unwrap();
 
         let packet_length = data_length_bytes.position() as usize + data.len();
-        VarInt(packet_length as i32).write(output, ProtocolVersion::V1_16_2);
-        VarInt(data_length as i32).write(output, ProtocolVersion::V1_16_2);
+        VarInt(packet_length as i32).write(output, ProtocolVersion::V1_16_2)?;
+        VarInt(data_length as i32).write(output, ProtocolVersion::V1_16_2)?;
         output.extend_from_slice(data);
 
         self.compression_target.clear();
+
+        Ok(())
     }
 
     fn data_compressed(&mut self) -> (usize, &[u8]) {
@@ -117,12 +121,14 @@ impl MinecraftCodec {
         (0, self.staging_buf.as_slice())
     }
 
-    fn encode_uncompressed(&mut self, output: &mut Vec<u8>) {
+    fn encode_uncompressed(&mut self, output: &mut Vec<u8>) -> anyhow::Result<()> {
         // TODO: we should probably be able to determine the length without writing the packet,
         // which could remove an unnecessary copy.
         let length = self.staging_buf.len() as i32;
-        VarInt(length).write(output, ProtocolVersion::V1_16_2);
+        VarInt(length).write(output, ProtocolVersion::V1_16_2)?;
         output.extend_from_slice(&self.staging_buf);
+
+        Ok(())
     }
 
     /// Accepts newly received bytes.

--- a/feather/protocol/src/io.rs
+++ b/feather/protocol/src/io.rs
@@ -299,7 +299,7 @@ impl Writeable for VarLong {
                 break;
             }
         }
-        
+
         Ok(())
     }
 }
@@ -343,7 +343,7 @@ impl Writeable for String {
     fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         VarInt(self.len() as i32).write(buffer, version)?;
         buffer.extend_from_slice(self.as_bytes());
-        
+
         Ok(())
     }
 }
@@ -417,7 +417,9 @@ where
 {
     fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         P::try_from(self.0.len())?.write(buffer, version)?;
-        self.0.iter().for_each(|item| item.write(buffer, version).expect("failed to write to vec"));
+        self.0
+            .iter()
+            .for_each(|item| item.write(buffer, version).expect("failed to write to vec"));
 
         Ok(())
     }
@@ -676,7 +678,11 @@ impl Writeable for EntityMetadata {
     }
 }
 
-fn write_meta_entry(entry: &MetaEntry, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+fn write_meta_entry(
+    entry: &MetaEntry,
+    buffer: &mut Vec<u8>,
+    version: ProtocolVersion,
+) -> anyhow::Result<()> {
     match entry {
         MetaEntry::Byte(x) => x.write(buffer, version)?,
         MetaEntry::VarInt(x) => {

--- a/feather/protocol/src/io.rs
+++ b/feather/protocol/src/io.rs
@@ -34,15 +34,16 @@ pub trait Readable {
 /// to a buffer.
 pub trait Writeable: Sized {
     /// Writes this value to the given buffer.
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion);
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()>;
 }
 
 impl<'a, T> Writeable for &'a T
 where
     T: Writeable,
 {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-        T::write(*self, buffer, version);
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+        T::write(*self, buffer, version)?;
+        Ok(())
     }
 }
 
@@ -63,8 +64,9 @@ macro_rules! integer_impl {
             }
 
             impl Writeable for $int {
-                fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
-                    buffer.$write_fn::<BigEndian>(*self).unwrap();
+                fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
+                    buffer.$write_fn::<BigEndian>(*self)?;
+                    Ok(())
                 }
             }
         )*
@@ -94,8 +96,9 @@ impl Readable for u8 {
 }
 
 impl Writeable for u8 {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
-        buffer.write_u8(*self).unwrap();
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
+        buffer.write_u8(*self)?;
+        Ok(())
     }
 }
 
@@ -109,8 +112,9 @@ impl Readable for i8 {
 }
 
 impl Writeable for i8 {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
-        buffer.write_i8(*self).unwrap()
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
+        buffer.write_i8(*self)?;
+        Ok(())
     }
 }
 
@@ -137,13 +141,15 @@ impl<T> Writeable for Option<T>
 where
     T: Writeable,
 {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         let present = self.is_some();
-        present.write(buffer, version);
+        present.write(buffer, version)?;
 
         if let Some(value) = self {
-            value.write(buffer, version);
+            value.write(buffer, version)?;
         }
+
+        Ok(())
     }
 }
 
@@ -226,8 +232,9 @@ impl VarInt {
 }
 
 impl Writeable for VarInt {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
         self.write_to(buffer).expect("write to Vec failed");
+        Ok(())
     }
 }
 
@@ -277,7 +284,7 @@ impl From<i64> for VarLong {
 }
 
 impl Writeable for VarLong {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
         let mut x = self.0 as u64;
         loop {
             let mut temp = (x & 0b0111_1111) as u8;
@@ -292,6 +299,8 @@ impl Writeable for VarLong {
                 break;
             }
         }
+        
+        Ok(())
     }
 }
 
@@ -331,9 +340,11 @@ impl Readable for String {
 }
 
 impl Writeable for String {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-        VarInt(self.len() as i32).write(buffer, version);
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+        VarInt(self.len() as i32).write(buffer, version)?;
         buffer.extend_from_slice(self.as_bytes());
+        
+        Ok(())
     }
 }
 
@@ -355,9 +366,11 @@ impl Readable for bool {
 }
 
 impl Writeable for bool {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         let x = if *self { 1u8 } else { 0 };
-        x.write(buffer, version);
+        x.write(buffer, version)?;
+
+        Ok(())
     }
 }
 
@@ -400,12 +413,13 @@ where
     T: Writeable,
     [T]: ToOwned<Owned = Vec<T>>,
     P: TryFrom<usize> + Writeable,
-    P::Error: std::fmt::Debug,
+    P::Error: std::error::Error + Send + Sync + 'static,
 {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-        P::try_from(self.0.len()).unwrap().write(buffer, version);
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+        P::try_from(self.0.len())?.write(buffer, version)?;
+        self.0.iter().for_each(|item| item.write(buffer, version).expect("failed to write to vec"));
 
-        self.0.iter().for_each(|item| item.write(buffer, version));
+        Ok(())
     }
 }
 
@@ -455,8 +469,9 @@ impl<'a> Readable for LengthInferredVecU8<'a> {
 }
 
 impl<'a> Writeable for LengthInferredVecU8<'a> {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
         buffer.extend_from_slice(&*self.0);
+        Ok(())
     }
 }
 
@@ -496,7 +511,7 @@ impl<T> Writeable for Nbt<T>
 where
     T: Serialize,
 {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
         nbt::to_writer(buffer, &self.0, None).unwrap_or_else(|e| {
             panic!(
                 "could not serialize struct of type '{}' to NBT: {}",
@@ -504,6 +519,8 @@ where
                 e
             )
         });
+
+        Ok(())
     }
 }
 
@@ -546,21 +563,23 @@ impl Readable for Slot {
 }
 
 impl Writeable for Slot {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-        self.is_some().write(buffer, version);
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+        self.is_some().write(buffer, version)?;
 
         if let Some(stack) = self {
-            VarInt(stack.item.id() as i32).write(buffer, version);
-            (stack.count as u8).write(buffer, version);
+            VarInt(stack.item.id() as i32).write(buffer, version)?;
+            (stack.count as u8).write(buffer, version)?;
 
             let tags: ItemNbt = stack.into();
             if tags != ItemNbt::default() {
                 dbg!();
-                Nbt(tags).write(buffer, version);
+                Nbt(tags).write(buffer, version)?;
             } else {
-                0u8.write(buffer, version); // TAG_End
+                0u8.write(buffer, version)?; // TAG_End
             }
         }
+
+        Ok(())
     }
 }
 
@@ -644,80 +663,83 @@ fn read_meta_entry(
 }
 
 impl Writeable for EntityMetadata {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         for (index, entry) in self.iter() {
-            index.write(buffer, version);
-            VarInt(entry.id()).write(buffer, version);
-            write_meta_entry(entry, buffer, version);
+            index.write(buffer, version)?;
+            VarInt(entry.id()).write(buffer, version)?;
+            write_meta_entry(entry, buffer, version)?;
         }
 
         // End of metadata
         buffer.push(0xFF);
+        Ok(())
     }
 }
 
-fn write_meta_entry(entry: &MetaEntry, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+fn write_meta_entry(entry: &MetaEntry, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
     match entry {
-        MetaEntry::Byte(x) => x.write(buffer, version),
+        MetaEntry::Byte(x) => x.write(buffer, version)?,
         MetaEntry::VarInt(x) => {
-            VarInt(*x).write(buffer, version);
+            VarInt(*x).write(buffer, version)?;
         }
-        MetaEntry::Float(x) => x.write(buffer, version),
-        MetaEntry::String(x) => x.write(buffer, version),
-        MetaEntry::Chat(x) => x.write(buffer, version),
+        MetaEntry::Float(x) => x.write(buffer, version)?,
+        MetaEntry::String(x) => x.write(buffer, version)?,
+        MetaEntry::Chat(x) => x.write(buffer, version)?,
         MetaEntry::OptChat(ox) => {
             if let Some(x) = ox {
-                true.write(buffer, version);
-                x.write(buffer, version);
+                true.write(buffer, version)?;
+                x.write(buffer, version)?;
             } else {
-                false.write(buffer, version);
+                false.write(buffer, version)?;
             }
         }
-        MetaEntry::Slot(slot) => slot.write(buffer, version),
-        MetaEntry::Boolean(x) => x.write(buffer, version),
+        MetaEntry::Slot(slot) => slot.write(buffer, version)?,
+        MetaEntry::Boolean(x) => x.write(buffer, version)?,
         MetaEntry::Rotation(x, y, z) => {
-            x.write(buffer, version);
-            y.write(buffer, version);
-            z.write(buffer, version);
+            x.write(buffer, version)?;
+            y.write(buffer, version)?;
+            z.write(buffer, version)?;
         }
-        MetaEntry::Position(x) => x.write(buffer, version),
+        MetaEntry::Position(x) => x.write(buffer, version)?,
         MetaEntry::OptPosition(ox) => {
             if let Some(x) = ox {
-                true.write(buffer, version);
-                x.write(buffer, version);
+                true.write(buffer, version)?;
+                x.write(buffer, version)?;
             } else {
-                false.write(buffer, version);
+                false.write(buffer, version)?;
             }
         }
-        MetaEntry::Direction(x) => VarInt(x.to_i32().unwrap()).write(buffer, version),
+        MetaEntry::Direction(x) => VarInt(x.to_i32().unwrap()).write(buffer, version)?,
         MetaEntry::OptUuid(ox) => {
             if let Some(x) = ox {
-                true.write(buffer, version);
-                x.write(buffer, version);
+                true.write(buffer, version)?;
+                x.write(buffer, version)?;
             } else {
-                false.write(buffer, version);
+                false.write(buffer, version)?;
             }
         }
         MetaEntry::OptBlockId(ox) => {
             if let Some(x) = ox {
-                VarInt(*x).write(buffer, version);
+                VarInt(*x).write(buffer, version)?;
             } else {
-                VarInt(0).write(buffer, version); // No value implies air
+                VarInt(0).write(buffer, version)?; // No value implies air
             }
         }
-        MetaEntry::Nbt(val) => Nbt(val).write(buffer, version),
+        MetaEntry::Nbt(val) => Nbt(val).write(buffer, version)?,
         MetaEntry::Particle => unimplemented!("entity metadata with particles"),
         MetaEntry::VillagerData => unimplemented!("entity metadata with villager data"),
         MetaEntry::OptVarInt(ox) => {
             if let Some(x) = ox {
-                true.write(buffer, version);
-                x.write(buffer, version);
+                true.write(buffer, version)?;
+                x.write(buffer, version)?;
             } else {
-                false.write(buffer, version);
+                false.write(buffer, version)?;
             }
         }
-        MetaEntry::Pose(x) => VarInt(x.to_i32().unwrap()).write(buffer, version),
+        MetaEntry::Pose(x) => VarInt(x.to_i32().unwrap()).write(buffer, version)?,
     }
+
+    Ok(())
 }
 
 impl Readable for Uuid {
@@ -733,8 +755,9 @@ impl Readable for Uuid {
 }
 
 impl Writeable for Uuid {
-    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, _version: ProtocolVersion) -> anyhow::Result<()> {
         buffer.extend_from_slice(self.as_bytes());
+        Ok(())
     }
 }
 
@@ -754,11 +777,13 @@ impl Readable for BlockPosition {
 }
 
 impl Writeable for BlockPosition {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         let val = ((self.x as u64 & 0x3FFFFFF) << 38)
             | ((self.z as u64 & 0x3FFFFFF) << 12)
             | (self.y as u64 & 0xFFF);
-        val.write(buffer, version);
+        val.write(buffer, version)?;
+
+        Ok(())
     }
 }
 
@@ -786,9 +811,11 @@ impl Readable for Angle {
 }
 
 impl Writeable for Angle {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         let val = (self.0 / 360.0 * 256.0).round() as u8;
-        val.write(buffer, version);
+        val.write(buffer, version)?;
+
+        Ok(())
     }
 }
 
@@ -805,8 +832,9 @@ impl Readable for BlockId {
 }
 
 impl Writeable for BlockId {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-        VarInt(self.vanilla_id().into()).write(buffer, version);
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+        VarInt(self.vanilla_id().into()).write(buffer, version)?;
+        Ok(())
     }
 }
 
@@ -827,13 +855,15 @@ impl Readable for Gamemode {
 }
 
 impl Writeable for Gamemode {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         let id = match self {
             Gamemode::Survival => 0,
             Gamemode::Creative => 1,
             Gamemode::Adventure => 2,
             Gamemode::Spectator => 3,
         };
-        (id as u8).write(buffer, version);
+        (id as u8).write(buffer, version)?;
+
+        Ok(())
     }
 }

--- a/feather/protocol/src/io.rs
+++ b/feather/protocol/src/io.rs
@@ -369,8 +369,7 @@ pub const MAX_LENGTH: usize = 1024 * 1024; // 2^20 elements
 /// This will reject arrays of lengths larger than MAX_LENGTH.
 pub struct LengthPrefixedVec<'a, P, T>(pub Cow<'a, [T]>, PhantomData<P>)
 where
-    [T]: ToOwned<Owned = Vec<T>>,
-    P: TryInto<usize>;
+    [T]: ToOwned<Owned = Vec<T>>;
 
 impl<'a, P, T> Readable for LengthPrefixedVec<'a, P, T>
 where
@@ -400,8 +399,8 @@ impl<'a, P, T> Writeable for LengthPrefixedVec<'a, P, T>
 where
     T: Writeable,
     [T]: ToOwned<Owned = Vec<T>>,
-    P: TryInto<usize> + TryFrom<usize> + Writeable,
-    <P as TryFrom<usize>>::Error: std::fmt::Debug,
+    P: TryFrom<usize> + Writeable,
+    P::Error: std::fmt::Debug,
 {
     fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
         P::try_from(self.0.len()).unwrap().write(buffer, version);
@@ -413,7 +412,6 @@ where
 impl<'a, P, T> From<LengthPrefixedVec<'a, P, T>> for Vec<T>
 where
     [T]: ToOwned<Owned = Vec<T>>,
-    P: TryInto<usize>,
 {
     fn from(x: LengthPrefixedVec<'a, P, T>) -> Self {
         x.0.into_owned()
@@ -423,7 +421,6 @@ where
 impl<'a, P, T> From<&'a [T]> for LengthPrefixedVec<'a, P, T>
 where
     [T]: ToOwned<Owned = Vec<T>>,
-    P: TryInto<usize>,
 {
     fn from(slice: &'a [T]) -> Self {
         Self(Cow::Borrowed(slice), PhantomData)
@@ -433,7 +430,6 @@ where
 impl<'a, P, T> From<Vec<T>> for LengthPrefixedVec<'a, P, T>
 where
     [T]: ToOwned<Owned = Vec<T>>,
-    P: TryInto<usize>,
 {
     fn from(vec: Vec<T>) -> Self {
         Self(Cow::Owned(vec), PhantomData)

--- a/feather/protocol/src/lib.rs
+++ b/feather/protocol/src/lib.rs
@@ -88,10 +88,10 @@ impl ClientPacketCodec {
     /// Encodes a `ClientPacket` into a buffer.
     pub fn encode(&mut self, packet: &ClientPacket, buffer: &mut Vec<u8>) {
         match packet {
-            ClientPacket::Handshake(packet) => self.codec.encode(packet, buffer),
-            ClientPacket::Status(packet) => self.codec.encode(packet, buffer),
-            ClientPacket::Login(packet) => self.codec.encode(packet, buffer),
-            ClientPacket::Play(packet) => self.codec.encode(packet, buffer),
+            ClientPacket::Handshake(packet) => self.codec.encode(packet, buffer).unwrap(),
+            ClientPacket::Status(packet) => self.codec.encode(packet, buffer).unwrap(),
+            ClientPacket::Login(packet) => self.codec.encode(packet, buffer).unwrap(),
+            ClientPacket::Play(packet) => self.codec.encode(packet, buffer).unwrap(),
         }
     }
 }
@@ -143,9 +143,9 @@ impl ServerPacketCodec {
     /// Encodes a `ServerPacket` into a buffer.
     pub fn encode(&mut self, packet: &ServerPacket, buffer: &mut Vec<u8>) {
         match packet {
-            ServerPacket::Status(packet) => self.codec.encode(packet, buffer),
-            ServerPacket::Login(packet) => self.codec.encode(packet, buffer),
-            ServerPacket::Play(packet) => self.codec.encode(packet, buffer),
+            ServerPacket::Status(packet) => self.codec.encode(packet, buffer).unwrap(),
+            ServerPacket::Login(packet) => self.codec.encode(packet, buffer).unwrap(),
+            ServerPacket::Play(packet) => self.codec.encode(packet, buffer).unwrap(),
         }
     }
 }

--- a/feather/protocol/src/packets.rs
+++ b/feather/protocol/src/packets.rs
@@ -2,7 +2,7 @@ macro_rules! user_type {
     (VarInt) => {
         i32
     };
-    (LengthPrefixedVec <$inner:ident>) => {
+    (VarIntPrefixedVec <$inner:ident>) => {
         Vec<$inner>
     };
     (ShortPrefixedVec <$inner:ident>) => {
@@ -23,8 +23,8 @@ macro_rules! user_type_convert_to_writeable {
     (VarInt, $e:expr) => {
         VarInt(*$e as i32)
     };
-    (LengthPrefixedVec <$inner:ident>, $e:expr) => {
-        LengthPrefixedVec::from($e.as_slice())
+    (VarIntPrefixedVec <$inner:ident>, $e:expr) => {
+        VarIntPrefixedVec::from($e.as_slice())
     };
     (ShortPrefixedVec <$inner:ident>, $e:expr) => {
         ShortPrefixedVec::from($e.as_slice())
@@ -281,7 +281,7 @@ pub trait VariantOf<Enum> {
         Self: Sized;
 }
 
-use crate::io::{Angle, LengthInferredVecU8, LengthPrefixedVec, Nbt, ShortPrefixedVec, VarInt};
+use crate::io::{Angle, LengthInferredVecU8, Nbt, ShortPrefixedVec, VarInt, VarIntPrefixedVec};
 use crate::Slot;
 use base::{BlockId, BlockPosition};
 use nbt::Blob;

--- a/feather/protocol/src/packets.rs
+++ b/feather/protocol/src/packets.rs
@@ -81,10 +81,11 @@ macro_rules! packets {
 
             #[allow(unused_variables)]
             impl crate::Writeable for $packet {
-                fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) {
+                fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) -> anyhow::Result<()> {
                     $(
-                        user_type_convert_to_writeable!($typ $(<$generics>)?, &self.$field).write(buffer, version);
+                        user_type_convert_to_writeable!($typ $(<$generics>)?, &self.$field).write(buffer, version)?;
                     )*
+                    Ok(())
                 }
             }
         )*
@@ -169,7 +170,7 @@ macro_rules! def_enum {
         }
 
         impl crate::Writeable for $ident {
-            fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) {
+            fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) -> anyhow::Result<()> {
                 match self {
                     $(
                         $ident::$variant $(
@@ -178,16 +179,17 @@ macro_rules! def_enum {
                             }
                         )? => {
                             let discriminant = <$discriminant_type>::from($discriminant);
-                            discriminant.write(buffer, version);
+                            discriminant.write(buffer, version)?;
 
                             $(
                                 $(
-                                    user_type_convert_to_writeable!($typ $(<$generics>)?, $field).write(buffer, version);
+                                    user_type_convert_to_writeable!($typ $(<$generics>)?, $field).write(buffer, version)?;
                                 )*
                             )?
                         }
                     )*
                 }
+                Ok(())
             }
         }
     };
@@ -233,15 +235,16 @@ macro_rules! packet_enum {
         }
 
         impl crate::Writeable for $ident {
-            fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) {
-                VarInt(self.id() as i32).write(buffer, version);
+            fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) -> anyhow::Result<()> {
+                VarInt(self.id() as i32).write(buffer, version)?;
                 match self {
                     $(
                         $ident::$packet(packet) => {
-                            packet.write(buffer, version);
+                            packet.write(buffer, version)?;
                         }
                     )*
                 }
+                Ok(())
             }
         }
 

--- a/feather/protocol/src/packets/client/login.rs
+++ b/feather/protocol/src/packets/client/login.rs
@@ -6,8 +6,8 @@ packets! {
     }
 
     EncryptionResponse {
-        shared_secret LengthPrefixedVec<u8>;
-        verify_token LengthPrefixedVec<u8>;
+        shared_secret VarIntPrefixedVec<u8>;
+        verify_token VarIntPrefixedVec<u8>;
     }
 
     LoginPluginResponse {

--- a/feather/protocol/src/packets/server/login.rs
+++ b/feather/protocol/src/packets/server/login.rs
@@ -7,8 +7,8 @@ packets! {
 
     EncryptionRequest {
         server_id String;
-        public_key LengthPrefixedVec<u8>;
-        verify_token LengthPrefixedVec<u8>;
+        public_key VarIntPrefixedVec<u8>;
+        verify_token VarIntPrefixedVec<u8>;
     }
 
     LoginSuccess {

--- a/feather/protocol/src/packets/server/play.rs
+++ b/feather/protocol/src/packets/server/play.rs
@@ -987,7 +987,7 @@ impl Writeable for EntityEquipment {
             slot_byte.write(buffer, version)?;
             entry.item.write(buffer, version)?;
         }
-        
+
         Ok(())
     }
 }

--- a/feather/protocol/src/packets/server/play.rs
+++ b/feather/protocol/src/packets/server/play.rs
@@ -97,7 +97,7 @@ def_enum! {
 
 packets! {
     Statistics {
-        statistics LengthPrefixedVec<Statistic>;
+        statistics VarIntPrefixedVec<Statistic>;
     }
 
     Statistic {
@@ -217,14 +217,14 @@ packets! {
     MultiBlockChange {
         chunk_section_coordinate u64;
         dont_trust_edges bool;
-        records LengthPrefixedVec<VarLong>;
+        records VarIntPrefixedVec<VarLong>;
     }
 
     TabComplete {
         id VarInt;
         start VarInt;
         length VarInt;
-        matches LengthPrefixedVec<TabCompleteMatch>;
+        matches VarIntPrefixedVec<TabCompleteMatch>;
     }
 
     TabCompleteMatch {
@@ -242,7 +242,7 @@ packets! {
 
     CommandNode {
         flags u8;
-        children LengthPrefixedVec<VarInt>;
+        children VarIntPrefixedVec<VarInt>;
         redirect_node Option<VarInt>;
         name Option<String>;
         parser Option<String>;
@@ -312,7 +312,7 @@ packets! {
         y f32;
         z f32;
         strength f32;
-        records LengthPrefixedVec<ExplosionRecord>;
+        records VarIntPrefixedVec<ExplosionRecord>;
         player_motion_x f32;
         player_motion_y f32;
         player_motion_z f32;
@@ -358,7 +358,7 @@ packets! {
         is_hardcore bool;
         gamemode Gamemode;
         previous_gamemode u8; // can be 255 if "not set," otherwise corresponds to a gamemode ID
-        world_names LengthPrefixedVec<String>;
+        world_names VarIntPrefixedVec<String>;
 
         dimension_codec Nbt<Blob>;
         dimension Nbt<Blob>;
@@ -381,7 +381,7 @@ packets! {
         scale i8;
         show_tracking_position bool;
         is_locked bool;
-        icons LengthPrefixedVec<Icon>;
+        icons VarIntPrefixedVec<Icon>;
         // TODO: a bunch of fields only if a Columns is set to 0
         __todo__ LengthInferredVecU8;
     }
@@ -814,7 +814,7 @@ packets! {
     }
 
     DestroyEntities {
-        entity_ids LengthPrefixedVec<VarInt>;
+        entity_ids VarIntPrefixedVec<VarInt>;
     }
 
     RemoveEntityEffect {
@@ -1027,7 +1027,7 @@ packets! {
 
     SetPassengers {
         entity_id VarInt;
-        passengers LengthPrefixedVec<VarInt>;
+        passengers VarIntPrefixedVec<VarInt>;
     }
 
     Teams {
@@ -1046,7 +1046,7 @@ def_enum! {
             team_color VarInt;
             team_prefix String;
             team_suffix String;
-            entities LengthPrefixedVec<String>; // usernames or UUIDs
+            entities VarIntPrefixedVec<String>; // usernames or UUIDs
         },
         1 = RemoveTeam,
         2 = UpdateTeamInfo {
@@ -1059,10 +1059,10 @@ def_enum! {
             team_suffix String;
         },
         3 = AddEntitiesToTeam {
-            entities LengthPrefixedVec<String>;
+            entities VarIntPrefixedVec<String>;
         },
         4 = RemoveEntitiesFromTeam {
-            entities LengthPrefixedVec<String>;
+            entities VarIntPrefixedVec<String>;
         },
     }
 }
@@ -1185,7 +1185,7 @@ def_enum! {
             id String;
             group String;
             ingredient VarInt;
-            ingredients LengthPrefixedVec<Ingredient>;
+            ingredients VarIntPrefixedVec<Ingredient>;
             result Slot;
         },
         "minecraft:crafting_shaped" = Shaped {
@@ -1193,7 +1193,7 @@ def_enum! {
             width VarInt;
             height VarInt;
             group String;
-            ingredients LengthPrefixedVec<Ingredient>;
+            ingredients VarIntPrefixedVec<Ingredient>;
             result Slot;
         },
         "minecraft:crafting_special_armordye" = ArmorDye { id String; },
@@ -1253,18 +1253,18 @@ def_enum! {
 
 packets! {
     Ingredient {
-        allowed_items LengthPrefixedVec<Slot>;
+        allowed_items VarIntPrefixedVec<Slot>;
     }
 
     AllTags {
-        block_tags LengthPrefixedVec<Tag>;
-        item_tags LengthPrefixedVec<Tag>;
-        fluid_tags LengthPrefixedVec<Tag>;
-        entity_tags LengthPrefixedVec<Tag>;
+        block_tags VarIntPrefixedVec<Tag>;
+        item_tags VarIntPrefixedVec<Tag>;
+        fluid_tags VarIntPrefixedVec<Tag>;
+        entity_tags VarIntPrefixedVec<Tag>;
     }
 
     Tag {
         name String;
-        entries LengthPrefixedVec<VarInt>;
+        entries VarIntPrefixedVec<VarInt>;
     }
 }

--- a/feather/protocol/src/packets/server/play/chunk_data.rs
+++ b/feather/protocol/src/packets/server/play/chunk_data.rs
@@ -53,14 +53,14 @@ impl ChunkData {
 }
 
 impl Writeable for ChunkData {
-    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
         let chunk = self.chunk.read();
 
-        chunk.position().x.write(buffer, version);
-        chunk.position().z.write(buffer, version);
+        chunk.position().x.write(buffer, version)?;
+        chunk.position().z.write(buffer, version)?;
 
         let full_chunk = matches!(self.kind, ChunkDataKind::LoadChunk);
-        full_chunk.write(buffer, version);
+        full_chunk.write(buffer, version)?;
 
         // Compute primary bit mask
         let mut bitmask = 0;
@@ -73,16 +73,16 @@ impl Writeable for ChunkData {
                 bitmask |= 1 << (y - 1) as i32;
             }
         }
-        VarInt(bitmask).write(buffer, version);
+        VarInt(bitmask).write(buffer, version)?;
 
         let heightmaps = build_heightmaps(&chunk);
-        Nbt(heightmaps).write(buffer, version);
+        Nbt(heightmaps).write(buffer, version)?;
 
         if full_chunk {
             // Write biomes (only if we're sending a new chunk)
-            VarInt(1024).write(buffer, version); // length of biomes
+            VarInt(1024).write(buffer, version)?; // length of biomes
             for &biome in chunk.biomes().as_slice() {
-                VarInt(biome.id() as i32).write(buffer, version);
+                VarInt(biome.id() as i32).write(buffer, version)?;
             }
         }
 
@@ -93,13 +93,15 @@ impl Writeable for ChunkData {
                 if self.should_skip_section(y) {
                     continue;
                 }
-                encode_section(section, &mut data, version);
+                encode_section(section, &mut data, version)?;
             }
         }
-        VarInt(data.len() as i32).write(buffer, version);
+        VarInt(data.len() as i32).write(buffer, version)?;
         buffer.extend_from_slice(&data);
 
-        VarInt(0).write(buffer, version); // number of block entities - always 0 for Feather
+        VarInt(0).write(buffer, version)?; // number of block entities - always 0 for Feather
+
+        Ok(())
     }
 }
 
@@ -110,22 +112,24 @@ fn build_heightmaps(chunk: &Chunk) -> Heightmaps {
     Heightmaps { motion_blocking }
 }
 
-fn encode_section(section: &ChunkSection, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-    (section.non_air_blocks() as u16).write(buffer, version);
-    (section.blocks().data().bits_per_value() as u8).write(buffer, version);
+fn encode_section(section: &ChunkSection, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+    (section.non_air_blocks() as u16).write(buffer, version)?;
+    (section.blocks().data().bits_per_value() as u8).write(buffer, version)?;
 
     if let Some(palette) = section.blocks().palette() {
-        VarInt(palette.len() as i32).write(buffer, version);
+        VarInt(palette.len() as i32).write(buffer, version)?;
         for &block in palette.as_slice() {
-            VarInt(block.vanilla_id() as i32).write(buffer, version);
+            VarInt(block.vanilla_id() as i32).write(buffer, version)?;
         }
     }
 
     let data = section.blocks().data().as_u64_slice();
-    VarInt(data.len() as i32).write(buffer, version);
+    VarInt(data.len() as i32).write(buffer, version)?;
     for &x in data {
-        x.write(buffer, version);
+        x.write(buffer, version)?;
     }
+
+    Ok(())
 }
 
 impl Readable for ChunkData {

--- a/feather/protocol/src/packets/server/play/chunk_data.rs
+++ b/feather/protocol/src/packets/server/play/chunk_data.rs
@@ -112,7 +112,11 @@ fn build_heightmaps(chunk: &Chunk) -> Heightmaps {
     Heightmaps { motion_blocking }
 }
 
-fn encode_section(section: &ChunkSection, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
+fn encode_section(
+    section: &ChunkSection,
+    buffer: &mut Vec<u8>,
+    version: ProtocolVersion,
+) -> anyhow::Result<()> {
     (section.non_air_blocks() as u16).write(buffer, version)?;
     (section.blocks().data().bits_per_value() as u8).write(buffer, version)?;
 

--- a/feather/protocol/src/packets/server/play/update_light.rs
+++ b/feather/protocol/src/packets/server/play/update_light.rs
@@ -19,12 +19,12 @@ impl Debug for UpdateLight {
 }
 
 impl Writeable for UpdateLight {
-    fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) {
+    fn write(&self, buffer: &mut Vec<u8>, version: crate::ProtocolVersion) -> anyhow::Result<()> {
         let chunk = self.chunk.read();
-        VarInt(chunk.position().x).write(buffer, version);
-        VarInt(chunk.position().z).write(buffer, version);
+        VarInt(chunk.position().x).write(buffer, version)?;
+        VarInt(chunk.position().z).write(buffer, version)?;
 
-        true.write(buffer, version); // trust edges?
+        true.write(buffer, version)?; // trust edges?
 
         let mut mask = 0;
         for (y, section) in chunk.sections().iter().enumerate() {
@@ -33,11 +33,11 @@ impl Writeable for UpdateLight {
             }
         }
 
-        VarInt(mask).write(buffer, version); // sky light mask
-        VarInt(mask).write(buffer, version); // block light mask
+        VarInt(mask).write(buffer, version)?; // sky light mask
+        VarInt(mask).write(buffer, version)?; // block light mask
 
-        VarInt(!mask).write(buffer, version); // empty sky light mask
-        VarInt(!mask).write(buffer, version); // empty block light mask
+        VarInt(!mask).write(buffer, version)?; // empty sky light mask
+        VarInt(!mask).write(buffer, version)?; // empty block light mask
 
         for section in chunk.sections().iter().flatten() {
             encode_light(section.light().sky_light(), buffer, version);
@@ -46,11 +46,13 @@ impl Writeable for UpdateLight {
         for section in chunk.sections().iter().flatten() {
             encode_light(section.light().block_light(), buffer, version);
         }
+
+        Ok(())
     }
 }
 
 fn encode_light(light: &PackedArray, buffer: &mut Vec<u8>, version: ProtocolVersion) {
-    VarInt(2048).write(buffer, version);
+    VarInt(2048).write(buffer, version).unwrap();
     let light_data: &[u8] = bytemuck::cast_slice(light.as_u64_slice());
     assert_eq!(light_data.len(), 2048);
     buffer.extend_from_slice(light_data);

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -214,7 +214,8 @@ impl Client {
         let mut data = Vec::new();
         "Feather"
             .to_owned()
-            .write(&mut data, ProtocolVersion::V1_16_2);
+            .write(&mut data, ProtocolVersion::V1_16_2)
+            .unwrap();
         self.send_plugin_message("minecraft:brand", data)
     }
 

--- a/feather/server/src/connection_worker.rs
+++ b/feather/server/src/connection_worker.rs
@@ -233,7 +233,7 @@ impl Writer {
     }
 
     pub async fn write(&mut self, packet: impl Writeable + Debug) -> anyhow::Result<()> {
-        self.codec.encode(&packet, &mut self.buffer);
+        self.codec.encode(&packet, &mut self.buffer)?;
         self.stream.write_all(&self.buffer).await?;
         self.buffer.clear();
         Ok(())

--- a/feather/server/src/initial_handler/proxy/velocity.rs
+++ b/feather/server/src/initial_handler/proxy/velocity.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use anyhow::bail;
 use base::ProfileProperty;
 use protocol::{
-    io::LengthPrefixedVec, packets::server::LoginPluginRequest, ClientLoginPacket, ProtocolVersion,
+    io::VarIntPrefixedVec, packets::server::LoginPluginRequest, ClientLoginPacket, ProtocolVersion,
     Readable, ServerLoginPacket, VarInt,
 };
 use ring::{
@@ -76,7 +76,7 @@ fn read_player_info(key: &str, payload: &[u8]) -> anyhow::Result<ProxyData> {
     let client = String::read(&mut payload, mcversion)?;
     let uuid = Uuid::read(&mut payload, mcversion)?;
     let _name = String::read(&mut payload, mcversion)?;
-    let properties = LengthPrefixedVec::<Property>::read(&mut payload, mcversion)?;
+    let properties = VarIntPrefixedVec::<Property>::read(&mut payload, mcversion)?;
 
     Ok(ProxyData {
         host: "".to_owned(),


### PR DESCRIPTION
# Make LengthPrefixedVec generic

## Status

- [x] Ready

## Description

Made it generic and added typedefs for compatibility with existing code, and removed `ShortPrefixedVec` implementation. As per this [conversation](https://discord.com/channels/619316022800809995/805342116057579520/829511984423632916). Honestly, I'm not sure if performance will suffer, but I hope not.

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)
