### PR TITLE
Fix bytes_read for compressed packets

### DIFF
--- a/feather/protocol/src/codec.rs
+++ b/feather/protocol/src/codec.rs
@@ -174,7 +174,7 @@ impl MinecraftCodec {
 
                 let packet = T::read(&mut cursor, ProtocolVersion::V1_16_2)?;
 
-                let bytes_read = cursor.position() as usize + length_field_length;
+                let bytes_read = length.0 as usize + length_field_length;
                 self.received_buf = self.received_buf.split_off(bytes_read);
 
                 self.compression_target.clear();


### PR DESCRIPTION
# Fix handling compressed packets from client

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

There was a problem with bytes_read when reading compressed packet, because of new cursor created with compression_target

## Related issues

#412

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)
