### PR TITLE
Player abilities packet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "quill/example-plugins/plugin-message",
     "quill/example-plugins/query-entities",
     "quill/example-plugins/simple",
+    "quill/example-plugins/observe-creativemode-flight-event",
 
     # Feather (common and server)
     "feather/utils",

--- a/feather/common/src/entities/player.rs
+++ b/feather/common/src/entities/player.rs
@@ -9,7 +9,7 @@ pub fn build_default(builder: &mut EntityBuilder) {
         .add(Player)
         .add(CreativeFlying(false))
         .add(EntityKind::Player);
-}   
+}
 
 /// The hotbar slot a player's cursor is currently on
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/feather/common/src/entities/player.rs
+++ b/feather/common/src/entities/player.rs
@@ -1,12 +1,15 @@
 use anyhow::bail;
 use base::EntityKind;
 use ecs::{EntityBuilder, SysResult};
-use quill_common::entities::Player;
+use quill_common::{components::CreativeFlying, entities::Player};
 
 pub fn build_default(builder: &mut EntityBuilder) {
     super::build_default(builder);
-    builder.add(Player).add(EntityKind::Player);
-}
+    builder
+        .add(Player)
+        .add(CreativeFlying(false))
+        .add(EntityKind::Player);
+}   
 
 /// The hotbar slot a player's cursor is currently on
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -67,7 +67,7 @@ pub fn handle_packet(
         ClientPlayPacket::ClientSettings(packet) => handle_client_settings(server, player, packet),
 
         ClientPlayPacket::PlayerAbilities(packet) => {
-            movement::handle_player_abilities(game, player_id,packet)
+            movement::handle_player_abilities(game, player_id, packet)
         }
 
         ClientPlayPacket::TeleportConfirm(_)

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -66,6 +66,10 @@ pub fn handle_packet(
 
         ClientPlayPacket::ClientSettings(packet) => handle_client_settings(server, player, packet),
 
+        ClientPlayPacket::PlayerAbilities(packet) => {
+            movement::handle_player_abilities(server, player, packet)
+        }
+
         ClientPlayPacket::TeleportConfirm(_)
         | ClientPlayPacket::QueryBlockNbt(_)
         | ClientPlayPacket::SetDifficulty(_)
@@ -84,7 +88,6 @@ pub fn handle_packet(
         | ClientPlayPacket::SteerBoat(_)
         | ClientPlayPacket::PickItem(_)
         | ClientPlayPacket::CraftRecipeRequest(_)
-        | ClientPlayPacket::PlayerAbilities(_)
         | ClientPlayPacket::EntityAction(_)
         | ClientPlayPacket::SteerVehicle(_)
         | ClientPlayPacket::SetDisplayedRecipe(_)

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -67,7 +67,7 @@ pub fn handle_packet(
         ClientPlayPacket::ClientSettings(packet) => handle_client_settings(server, player, packet),
 
         ClientPlayPacket::PlayerAbilities(packet) => {
-            movement::handle_player_abilities(server, player, packet)
+            movement::handle_player_abilities(game, player_id,packet)
         }
 
         ClientPlayPacket::TeleportConfirm(_)

--- a/feather/server/src/packet_handlers/movement.rs
+++ b/feather/server/src/packet_handlers/movement.rs
@@ -1,9 +1,7 @@
 use base::Position;
 use ecs::{EntityRef, SysResult};
-use protocol::packets::client::{
-    PlayerMovement, PlayerPosition, PlayerPositionAndRotation, PlayerRotation,
-};
-use quill_common::components::OnGround;
+use protocol::packets::{client::{PlayerAbilities, PlayerMovement, PlayerPosition, PlayerPositionAndRotation, PlayerRotation}};
+use quill_common::components::{CreativeFlying, OnGround};
 
 use crate::{ClientId, Server};
 
@@ -88,4 +86,56 @@ fn update_client_position(server: &Server, player: EntityRef, pos: Position) -> 
         client.set_client_known_position(pos);
     }
     Ok(())
+}
+
+/// Handles the PlayerAbilities packet that signals, if the client wants to 
+/// start/stop flying (like in creative mode).
+pub fn handle_player_abilities(
+    server: &Server,
+    player: EntityRef,
+    packet: PlayerAbilities,
+) -> SysResult {
+
+    let mut flying = player.get_mut::<CreativeFlying>()?;
+
+    match packet.flags {
+        0 => {
+            // Flying stopped
+            
+            if flying.0 {
+                // Then it used to fly, therefor we need to trigger a event
+                // The vanilla client is actually quite good at keeping track of sending
+                // this packet only when there is a change, so this if should basically
+                // always trigger. 
+                
+                // @TODO
+            }
+
+            flying.0 = false;
+        },
+        2 => {
+            // Flying started
+
+            if ! flying.0 {
+                // Then it used to not fly, therefor we need to trigger a event.
+                // The vanilla client is actually quite good at keeping track of sending
+                // this packet only when there is a change, so this if should basically
+                // always trigger. 
+
+                
+                // @TODO
+            }
+            
+            flying.0 = false;
+        },
+        err => {
+            // Unexpected flat value
+            log::error!("Got a unexpected flag in the PlayerAbilities packet. The value was: {} and not 0 or 2.", err)
+        }
+    }
+
+    Ok(())
+
+
+
 }

--- a/quill/common/src/component.rs
+++ b/quill/common/src/component.rs
@@ -183,7 +183,9 @@ host_component_enum! {
         Particle = 1005,
         InteractEntityEvent = 1006,
         BlockPlacementEvent = 1007,
-        BlockInteractEvent = 1008
+        BlockInteractEvent = 1008,
+        CreativeFlying = 1009,
+
     }
 }
 
@@ -303,6 +305,14 @@ macro_rules! pod_component_impl {
 
 pod_component_impl!(Position);
 
+/**
+If you are using this macro and you get the error:
+```
+    error[E0599]: no variant or associated item named `...` found for enum `HostComponent` in the current scope. 
+```
+Then you need to go to the top of the file were this macro is defined. There you find the HostCompoent enum, that 
+you need to add your component to. 
+*/
 macro_rules! bincode_component_impl {
     ($type:ident) => {
         unsafe impl crate::Component for $type {

--- a/quill/common/src/component.rs
+++ b/quill/common/src/component.rs
@@ -185,6 +185,7 @@ host_component_enum! {
         BlockPlacementEvent = 1007,
         BlockInteractEvent = 1008,
         CreativeFlying = 1009,
+        CreativeFlyingEvent = 1010,
 
     }
 }
@@ -308,10 +309,10 @@ pod_component_impl!(Position);
 /**
 If you are using this macro and you get the error:
 ```
-    error[E0599]: no variant or associated item named `...` found for enum `HostComponent` in the current scope. 
+    error[E0599]: no variant or associated item named `...` found for enum `HostComponent` in the current scope.
 ```
-Then you need to go to the top of the file were this macro is defined. There you find the HostCompoent enum, that 
-you need to add your component to. 
+Then you need to go to the top of the file were this macro is defined. There you find the HostCompoent enum, that
+you need to add your component to.
 */
 macro_rules! bincode_component_impl {
     ($type:ident) => {
@@ -346,3 +347,4 @@ bincode_component_impl!(Particle);
 bincode_component_impl!(InteractEntityEvent);
 bincode_component_impl!(BlockPlacementEvent);
 bincode_component_impl!(BlockInteractEvent);
+bincode_component_impl!(CreativeFlyingEvent);

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -99,7 +99,7 @@ impl Display for CustomName {
     }
 }
 
-/// Whether an entity is flying (like in creative mode) 
+/// Whether an entity is flying (like in creative mode)
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CreativeFlying(pub bool);
 

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -98,3 +98,9 @@ impl Display for CustomName {
         self.0.fmt(f)
     }
 }
+
+/// Whether an entity is flying (like in creative mode) 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CreativeFlying(pub bool);
+
+bincode_component_impl!(CreativeFlying);

--- a/quill/common/src/events.rs
+++ b/quill/common/src/events.rs
@@ -1,7 +1,7 @@
 mod block_interact;
-mod interact_entity;
 mod change;
+mod interact_entity;
 
 pub use block_interact::{BlockInteractEvent, BlockPlacementEvent};
-pub use interact_entity::InteractEntityEvent;
 pub use change::CreativeFlyingEvent;
+pub use interact_entity::InteractEntityEvent;

--- a/quill/common/src/events.rs
+++ b/quill/common/src/events.rs
@@ -1,5 +1,7 @@
 mod block_interact;
 mod interact_entity;
+mod change;
 
 pub use block_interact::{BlockInteractEvent, BlockPlacementEvent};
 pub use interact_entity::InteractEntityEvent;
+pub use change::CreativeFlyingEvent;

--- a/quill/common/src/events/change.rs
+++ b/quill/common/src/events/change.rs
@@ -7,7 +7,7 @@ pub struct CreativeFlyingEvent {
 impl CreativeFlyingEvent {
     pub fn new(changed_to: bool) -> Self {
         Self {
-            is_flying: changed_to
+            is_flying: changed_to,
         }
     }
 }

--- a/quill/common/src/events/change.rs
+++ b/quill/common/src/events/change.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreativeFlyingEvent {
+    pub is_flying: bool,
+}
+
+impl CreativeFlyingEvent {
+    pub fn new(changed_to: bool) -> Self {
+        Self {
+            is_flying: changed_to
+        }
+    }
+}

--- a/quill/example-plugins/observe-creativemode-flight-event/Cargo.toml
+++ b/quill/example-plugins/observe-creativemode-flight-event/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "observe-creativemode-flight-event"
+version = "0.1.0"
+authors = ["Miro Andrin <miro.sveits@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+quill = { path = "../../api" }

--- a/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
+++ b/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
@@ -3,10 +3,7 @@ This plugin observers the CreativeFlightEvent printing a msg when someone starts
 flying.
 */
 
-use quill::{
-    events::CreativeFlyingEvent,
-    Game,Plugin,Setup,
-};
+use quill::{events::CreativeFlyingEvent, Game, Plugin, Setup};
 
 quill::plugin!(FlightPlugin);
 

--- a/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
+++ b/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
@@ -1,0 +1,32 @@
+/*
+This plugin observers the CreativeFlightEvent printing a msg when someone starts
+flying.
+*/
+
+use quill::{
+    events::CreativeFlyingEvent,
+    Game,Plugin,Setup,
+};
+
+quill::plugin!(FlightPlugin);
+
+struct FlightPlugin {}
+
+impl Plugin for FlightPlugin {
+    fn enable(_game: &mut Game, setup: &mut Setup<Self>) -> Self {
+        setup.add_system(flight_observer_system);
+        FlightPlugin {}
+    }
+
+    fn disable(self, _game: &mut Game) {}
+}
+
+fn flight_observer_system(_plugin: &mut FlightPlugin, game: &mut Game) {
+    for (entity, change) in game.query::<&CreativeFlyingEvent>() {
+        if change.is_flying {
+            entity.send_message("Enjoy your flight!");
+        } else {
+            entity.send_message("Hope you enjoyed your flight.");
+        }
+    }
+}


### PR DESCRIPTION
Implemented everything in #422,  except the parts about kicking players that use this packet when not in creative mode. I also added a small example plugin in quill that prints a short msg when a player starts or stops flying. 

I have run:
```
cargo clippy --all -- -D warnings
```
And eventually:
```
cargo fmt
```
And tested the example plugin. 