### PR TITLE
Implemented sneak tracking.

### DIFF
--- a/feather/common/src/entities/player.rs
+++ b/feather/common/src/entities/player.rs
@@ -1,13 +1,17 @@
 use anyhow::bail;
 use base::EntityKind;
 use ecs::{EntityBuilder, SysResult};
-use quill_common::{components::CreativeFlying, entities::Player};
+use quill_common::{
+    components::{CreativeFlying, Sneaking},
+    entities::Player,
+};
 
 pub fn build_default(builder: &mut EntityBuilder) {
     super::build_default(builder);
     builder
         .add(Player)
         .add(CreativeFlying(false))
+        .add(Sneaking(false))
         .add(EntityKind::Player);
 }
 

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -16,6 +16,7 @@ use quill_common::components::Name;
 
 use crate::{NetworkId, Server};
 
+mod entity_action;
 mod interaction;
 pub mod inventory;
 mod movement;
@@ -70,6 +71,10 @@ pub fn handle_packet(
             movement::handle_player_abilities(game, player_id, packet)
         }
 
+        ClientPlayPacket::EntityAction(packet) => {
+            entity_action::handle_entity_action(game, player_id, packet)
+        }
+
         ClientPlayPacket::TeleportConfirm(_)
         | ClientPlayPacket::QueryBlockNbt(_)
         | ClientPlayPacket::SetDifficulty(_)
@@ -88,7 +93,6 @@ pub fn handle_packet(
         | ClientPlayPacket::SteerBoat(_)
         | ClientPlayPacket::PickItem(_)
         | ClientPlayPacket::CraftRecipeRequest(_)
-        | ClientPlayPacket::EntityAction(_)
         | ClientPlayPacket::SteerVehicle(_)
         | ClientPlayPacket::SetDisplayedRecipe(_)
         | ClientPlayPacket::SetRecipeBookState(_)

--- a/feather/server/src/packet_handlers/entity_action.rs
+++ b/feather/server/src/packet_handlers/entity_action.rs
@@ -1,0 +1,59 @@
+use common::Game;
+use ecs::{Entity, SysResult};
+use protocol::packets::client::{EntityAction, EntityActionKind};
+use quill_common::{components::Sneaking, events::SneakEvent};
+
+///  From [wiki](https://wiki.vg/Protocol#Entity_Action)
+///  Sent by the client to indicate that it has performed certain actions:
+///  *) sneaking (crouching),
+///  *) sprinting,
+///  *) exiting a bed,
+///  *) jumping with a horse,
+///  *) opening a horse's inventory while riding it.
+///
+pub fn handle_entity_action(game: &mut Game, player: Entity, packet: EntityAction) -> SysResult {
+    match packet.action_id {
+        EntityActionKind::StartSneaking => {
+            let is_sneaking = game.ecs.get_mut::<Sneaking>(player)?.0;
+            if !is_sneaking {
+                game.ecs
+                    .insert_entity_event(player, SneakEvent::new(true))?;
+                game.ecs.get_mut::<Sneaking>(player)?.0 = true;
+            }
+        }
+        EntityActionKind::StopSneaking => {
+            let is_sneaking = game.ecs.get_mut::<Sneaking>(player)?.0;
+            if is_sneaking {
+                game.ecs
+                    .insert_entity_event(player, SneakEvent::new(false))?;
+                game.ecs.get_mut::<Sneaking>(player)?.0 = false;
+            }
+        }
+        EntityActionKind::LeaveBed => {
+            //TODO issue #423
+            // Note that the leave bed packet is not sent if the server changes night to day
+            // and all players are kicked out of the bed. We have to seperatly send out
+            // a notice that bed state might have changed.
+        }
+        EntityActionKind::StartSprinting => {
+            //TODO issue #423
+        }
+        EntityActionKind::StopSprinting => {
+            //TODO issue #423
+        }
+        EntityActionKind::StartHorseJump => {
+            //TODO issue #423
+        }
+        EntityActionKind::StopJorseJump => {
+            //TODO issue #423
+        }
+        EntityActionKind::OpenHorseInventory => {
+            //TODO issue #423
+        }
+        EntityActionKind::StartElytraFlight => {
+            //TODO issue #423
+        }
+    }
+
+    Ok(())
+}

--- a/feather/server/src/packet_handlers/movement.rs
+++ b/feather/server/src/packet_handlers/movement.rs
@@ -94,7 +94,7 @@ fn update_client_position(server: &Server, player: EntityRef, pos: Position) -> 
     Ok(())
 }
 
-/// Handles the PlayerAbilities packet that signals, if the client wants to
+/// Handles the PlayerAbilities packet that signals that the client wants to
 /// start/stop flying (like in creative mode).
 pub fn handle_player_abilities(
     game: &mut Game,

--- a/quill/common/src/component.rs
+++ b/quill/common/src/component.rs
@@ -186,6 +186,9 @@ host_component_enum! {
         BlockInteractEvent = 1008,
         CreativeFlying = 1009,
         CreativeFlyingEvent = 1010,
+        Sneaking = 1011,
+        SneakEvent = 1012,
+
 
     }
 }
@@ -348,3 +351,4 @@ bincode_component_impl!(InteractEntityEvent);
 bincode_component_impl!(BlockPlacementEvent);
 bincode_component_impl!(BlockInteractEvent);
 bincode_component_impl!(CreativeFlyingEvent);
+bincode_component_impl!(SneakEvent);

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -99,8 +99,13 @@ impl Display for CustomName {
     }
 }
 
-/// Whether an entity is flying (like in creative mode)
+/// Whether an entity is flying (like in creative mode, so it does not reflect if the player is flying by other means)
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CreativeFlying(pub bool);
 
 bincode_component_impl!(CreativeFlying);
+
+/// Wheather an entity is sneaking, like in pressing shift.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Sneaking(pub bool);
+bincode_component_impl!(Sneaking);

--- a/quill/common/src/events.rs
+++ b/quill/common/src/events.rs
@@ -3,5 +3,5 @@ mod change;
 mod interact_entity;
 
 pub use block_interact::{BlockInteractEvent, BlockPlacementEvent};
-pub use change::CreativeFlyingEvent;
+pub use change::{CreativeFlyingEvent, SneakEvent};
 pub use interact_entity::InteractEntityEvent;

--- a/quill/common/src/events/change.rs
+++ b/quill/common/src/events/change.rs
@@ -1,4 +1,9 @@
+/*
+All events in this file are triggerd when there is a change in a certain value.
+*/
+
 use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CreativeFlyingEvent {
     pub is_flying: bool,
@@ -8,6 +13,19 @@ impl CreativeFlyingEvent {
     pub fn new(changed_to: bool) -> Self {
         Self {
             is_flying: changed_to,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SneakEvent {
+    pub is_sneaking: bool,
+}
+
+impl SneakEvent {
+    pub fn new(changed_to: bool) -> Self {
+        Self {
+            is_sneaking: changed_to,
         }
     }
 }

--- a/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
+++ b/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
@@ -3,7 +3,10 @@ This plugin observers the CreativeFlightEvent printing a msg when someone starts
 flying.
 */
 
-use quill::{events::CreativeFlyingEvent, Game, Plugin, Setup};
+use quill::{
+    events::{CreativeFlyingEvent, SneakEvent},
+    Game, Plugin, Setup,
+};
 
 quill::plugin!(FlightPlugin);
 
@@ -12,6 +15,7 @@ struct FlightPlugin {}
 impl Plugin for FlightPlugin {
     fn enable(_game: &mut Game, setup: &mut Setup<Self>) -> Self {
         setup.add_system(flight_observer_system);
+        setup.add_system(sneak_observer_system);
         FlightPlugin {}
     }
 
@@ -24,6 +28,16 @@ fn flight_observer_system(_plugin: &mut FlightPlugin, game: &mut Game) {
             entity.send_message("Enjoy your flight!");
         } else {
             entity.send_message("Hope you enjoyed your flight.");
+        }
+    }
+}
+
+fn sneak_observer_system(_plugin: &mut FlightPlugin, game: &mut Game) {
+    for (player, change) in game.query::<&SneakEvent>() {
+        if change.is_sneaking {
+            player.send_message("Enjoy sneaking!");
+        } else {
+            player.send_message("How was it to be sneaking?");
         }
     }
 }


### PR DESCRIPTION
# Implemented sneaking tracking

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description
I have implemented sneaking tracking, such that a event is trigged when i a players starts or stops sneaking, and one can query for a 'Sneaking' component on player entities.  I also tested this is one of the example plugins. 

## Related issues
#423 

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)
