### PR TITLE
Add the ability to create queries that mutate host components within plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bytemuck",
+ "itertools 0.10.0",
  "libcraft-blocks",
  "libcraft-core",
  "libcraft-particles",

--- a/quill/api/Cargo.toml
+++ b/quill/api/Cargo.toml
@@ -15,4 +15,5 @@ quill-sys = { path = "../sys" }
 quill-common = { path = "../common" }
 thiserror = "1"
 uuid = "0.8"
+itertools = "0.10.0"
 

--- a/quill/api/src/entity.rs
+++ b/quill/api/src/entity.rs
@@ -70,11 +70,11 @@ impl Entity {
         }
     }
 
-    /// Sets or replaces a component of this entity.
+    /// Inserts or replaces a component of this entity.
     ///
     /// If the entity already has this component,
     /// the component is overwritten.
-    pub fn set<T: Component>(&self, component: T) {
+    pub fn insert<T: Component>(&self, component: T) {
         let host_component = T::host_component();
         let bytes = component.to_cow_bytes();
 

--- a/quill/api/src/game.rs
+++ b/quill/api/src/game.rs
@@ -109,7 +109,7 @@ impl Game {
     ///    println!("Found an entity with position {:?} and UUID {}", position, uuid);
     /// }
     /// ```
-    pub fn query<Q: Query>(&self) -> QueryIter<Q> {
+    pub fn query<Q: Query>(&mut self) -> QueryIter<Q> {
         QueryIter::new()
     }
 

--- a/quill/api/src/query.rs
+++ b/quill/api/src/query.rs
@@ -91,11 +91,7 @@ where
     }
 
     fn borrowed_mut(ty: HostComponent) -> bool {
-        if ty == T::host_component() {
-            true
-        } else {
-            false
-        }
+        ty == T::host_component()
     }
 
     unsafe fn get_unchecked(
@@ -182,13 +178,11 @@ where
         Q::add_component_types(&mut component_types);
 
         for (component_type, count) in component_types.clone().into_iter().counts() {
-            if count > 1 {
-                if Q::borrowed_mut(component_type) {
-                    panic!(
-                        "{:?} was borrowed mutably and immutably at the same time",
-                        component_type
-                    )
-                }
+            if count > 1 && Q::borrowed_mut(component_type) {
+                panic!(
+                    "{:?} was borrowed mutably and immutably at the same time",
+                    component_type
+                )
             }
         }
 

--- a/quill/api/src/query.rs
+++ b/quill/api/src/query.rs
@@ -1,8 +1,10 @@
 //! Query for all entities with a certain set of components.
 
-use std::{marker::PhantomData, mem::MaybeUninit};
+use std::{marker::PhantomData, mem::MaybeUninit, ops::{Deref, DerefMut}};
 
 use quill_common::{entity::QueryData, Component, HostComponent, PointerMut};
+
+use itertools::Itertools;
 
 use crate::{Entity, EntityId};
 
@@ -11,8 +13,11 @@ use crate::{Entity, EntityId};
 /// Implemented for tuples of `Query`s as well.
 pub trait Query {
     type Item;
+    type Target;
 
     fn add_component_types(types: &mut Vec<HostComponent>);
+
+    fn borrowed_mut(ty: HostComponent) -> bool;
 
     /// # Safety
     /// `component_index` must be a valid index less
@@ -24,7 +29,8 @@ pub trait Query {
         data: &QueryData,
         component_index: &mut usize,
         component_offsets: &mut [usize],
-    ) -> Self::Item;
+        entity: Entity
+    ) -> Self::Target;
 }
 
 impl<'a, T> Query for &'a T
@@ -33,16 +39,22 @@ where
     [T]: ToOwned,
 {
     type Item = T;
+    type Target = T;
 
     fn add_component_types(types: &mut Vec<HostComponent>) {
         types.push(T::host_component());
+    }
+
+    fn borrowed_mut(_: HostComponent) -> bool {
+        false
     }
 
     unsafe fn get_unchecked(
         data: &QueryData,
         component_index: &mut usize,
         component_offsets: &mut [usize],
-    ) -> T {
+        _: Entity
+    ) -> Self::Target {
         let component_len = *((data.component_lens.as_mut_ptr()).add(*component_index)) as usize;
         let component_ptr =
             (*(data.component_ptrs.as_mut_ptr().add(*component_index))).as_mut_ptr();
@@ -62,26 +74,81 @@ where
     }
 }
 
+impl<'a, T> Query for &'a mut T
+where
+    T: Component,
+    [T]: ToOwned,
+{
+    type Item = T;
+    type Target = Mut<T>;
+
+    fn add_component_types(types: &mut Vec<HostComponent>) {
+        types.push(T::host_component());
+    }
+    
+    fn borrowed_mut(ty: HostComponent) -> bool {
+        if ty == T::host_component() {
+            true
+        } else {
+            false
+        }
+    }
+
+    unsafe fn get_unchecked(
+        data: &QueryData,
+        component_index: &mut usize,
+        component_offsets: &mut [usize],
+        entity: Entity
+    ) -> Self::Target {
+        let component_len = *((data.component_lens.as_mut_ptr()).add(*component_index)) as usize;
+        let component_ptr =
+            (*(data.component_ptrs.as_mut_ptr().add(*component_index))).as_mut_ptr();
+
+        let offset = component_offsets[*component_index];
+        let component_ptr = component_ptr.add(offset);
+        let component_len = component_len - offset;
+
+        let component_bytes = std::slice::from_raw_parts(component_ptr, component_len);
+        let (value, advance) = T::from_bytes_unchecked(component_bytes);
+
+        component_offsets[*component_index] += advance;
+
+        *component_index += 1;
+
+        Mut(value, entity)
+    }
+}
+
 macro_rules! impl_query_tuple {
     ($($query:ident),* $(,)?) => {
         impl <$($query: Query),*> Query for ($($query,)*) {
             type Item = ($($query::Item),*);
+            type Target = ($($query::Target),*);
+
+            fn borrowed_mut(ty: HostComponent) -> bool {
+                $(if $query::borrowed_mut(ty) { return true; })*
+
+                return false;
+            }
+
             fn add_component_types(types: &mut Vec<HostComponent>) {
                 $(
                     $query::add_component_types(types);
                 )*
             }
 
-            unsafe fn get_unchecked(data: &QueryData, component_index: &mut usize, component_offsets: &mut [usize]) -> Self::Item {
+            unsafe fn get_unchecked(data: &QueryData, component_index: &mut usize, component_offsets: &mut [usize], entity: Entity) -> Self::Target {
                 (
                     $(
-                        $query::get_unchecked(data, component_index, component_offsets)
+                        $query::get_unchecked(data, component_index, component_offsets, Entity::new(entity.id()))
                     ),*
                 )
             }
         }
     }
 }
+
+
 
 impl_query_tuple!(A, B);
 impl_query_tuple!(A, B, C);
@@ -112,6 +179,14 @@ where
         let mut component_types = Vec::new();
         Q::add_component_types(&mut component_types);
 
+        for (component_type, count) in component_types.clone().into_iter().counts() {
+            if count > 1 {
+                if Q::borrowed_mut(component_type) {
+                    panic!("{:?} was borrowed mutably and immutably at the same time", component_type)
+                }
+            }
+        }
+
         let mut data = MaybeUninit::uninit();
         let data = unsafe {
             quill_sys::entity_query(
@@ -138,12 +213,15 @@ impl<Q> Iterator for QueryIter<Q>
 where
     Q: Query,
 {
-    type Item = (Entity, Q::Item);
-
+    type Item = (Entity, Q::Target);
+ 
     fn next(&mut self) -> Option<Self::Item> {
         if self.entity_index >= self.data.num_entities as usize {
             return None;
         }
+
+        let entity_id = unsafe { *(self.data.entities_ptr.as_mut_ptr()).add(self.entity_index) };
+        let entity = Entity::new(EntityId(entity_id));
 
         let components = unsafe {
             let mut component_index = 0;
@@ -151,13 +229,44 @@ where
                 &self.data,
                 &mut component_index,
                 &mut self.component_offsets,
+                Entity::new(entity.id())
             )
         };
-        let entity_id = unsafe { *(self.data.entities_ptr.as_mut_ptr()).add(self.entity_index) };
-        let entity = Entity::new(EntityId(entity_id));
 
         self.entity_index += 1;
 
         Some((entity, components))
+    }
+}
+
+pub struct Mut<T: Component>(T, Entity);
+
+impl<T: Component> Deref for Mut<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Component> DerefMut for Mut<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Component> std::ops::Drop for Mut<T> {
+    fn drop(&mut self) {
+        let host_component = T::host_component();
+        let bytes = self.0.to_cow_bytes();
+
+        unsafe {
+            quill_sys::entity_set_component(
+                self.1.id().0,
+                host_component,
+                bytes.as_ptr().into(),
+                bytes.len() as u32,
+            );
+        }
     }
 }

--- a/quill/api/src/query.rs
+++ b/quill/api/src/query.rs
@@ -1,6 +1,10 @@
 //! Query for all entities with a certain set of components.
 
-use std::{marker::PhantomData, mem::MaybeUninit, ops::{Deref, DerefMut}};
+use std::{
+    marker::PhantomData,
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+};
 
 use quill_common::{entity::QueryData, Component, HostComponent, PointerMut};
 
@@ -29,7 +33,7 @@ pub trait Query {
         data: &QueryData,
         component_index: &mut usize,
         component_offsets: &mut [usize],
-        entity: Entity
+        entity: Entity,
     ) -> Self::Target;
 }
 
@@ -53,7 +57,7 @@ where
         data: &QueryData,
         component_index: &mut usize,
         component_offsets: &mut [usize],
-        _: Entity
+        _: Entity,
     ) -> Self::Target {
         let component_len = *((data.component_lens.as_mut_ptr()).add(*component_index)) as usize;
         let component_ptr =
@@ -85,7 +89,7 @@ where
     fn add_component_types(types: &mut Vec<HostComponent>) {
         types.push(T::host_component());
     }
-    
+
     fn borrowed_mut(ty: HostComponent) -> bool {
         if ty == T::host_component() {
             true
@@ -98,7 +102,7 @@ where
         data: &QueryData,
         component_index: &mut usize,
         component_offsets: &mut [usize],
-        entity: Entity
+        entity: Entity,
     ) -> Self::Target {
         let component_len = *((data.component_lens.as_mut_ptr()).add(*component_index)) as usize;
         let component_ptr =
@@ -148,8 +152,6 @@ macro_rules! impl_query_tuple {
     }
 }
 
-
-
 impl_query_tuple!(A, B);
 impl_query_tuple!(A, B, C);
 impl_query_tuple!(A, B, C, D);
@@ -182,7 +184,10 @@ where
         for (component_type, count) in component_types.clone().into_iter().counts() {
             if count > 1 {
                 if Q::borrowed_mut(component_type) {
-                    panic!("{:?} was borrowed mutably and immutably at the same time", component_type)
+                    panic!(
+                        "{:?} was borrowed mutably and immutably at the same time",
+                        component_type
+                    )
                 }
             }
         }
@@ -214,7 +219,7 @@ where
     Q: Query,
 {
     type Item = (Entity, Q::Target);
- 
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.entity_index >= self.data.num_entities as usize {
             return None;
@@ -229,7 +234,7 @@ where
                 &self.data,
                 &mut component_index,
                 &mut self.component_offsets,
-                Entity::new(entity.id())
+                Entity::new(entity.id()),
             )
         };
 

--- a/quill/example-plugins/query-entities/src/lib.rs
+++ b/quill/example-plugins/query-entities/src/lib.rs
@@ -39,6 +39,6 @@ fn query_system(plugin: &mut QueryEntities, game: &mut Game) {
     // Make the piglin brutes float into the air.
     plugin.tick_counter += 1;
     for (_, (mut position, _piglin_brute)) in game.query::<(&mut Position, &PiglinBrute)>() {
-        position.y = position.y + 0.1 * ((plugin.tick_counter as f64 / 20.0).sin() + 1.0);
+        position.y += 0.1 * ((plugin.tick_counter as f64 / 20.0).sin() + 1.0);
     }
 }

--- a/quill/example-plugins/query-entities/src/lib.rs
+++ b/quill/example-plugins/query-entities/src/lib.rs
@@ -38,13 +38,7 @@ impl Plugin for QueryEntities {
 fn query_system(plugin: &mut QueryEntities, game: &mut Game) {
     // Make the piglin brutes float into the air.
     plugin.tick_counter += 1;
-    for (entity, (position, _piglin_brute)) in game.query::<(&Position, &PiglinBrute)>() {
-        // Mutable access to components through queries
-        // is not yet implemented, so we have to set
-        // the component directly.
-        entity.set(Position {
-            y: position.y + 0.1 * ((plugin.tick_counter as f64 / 20.0).sin() + 1.0),
-            ..position
-        });
+    for (_, (mut position, _piglin_brute)) in game.query::<(&mut Position, &PiglinBrute)>() {
+        position.y = position.y + 0.1 * ((plugin.tick_counter as f64 / 20.0).sin() + 1.0);
     }
 }

--- a/quill/example-plugins/simple/src/lib.rs
+++ b/quill/example-plugins/simple/src/lib.rs
@@ -40,12 +40,10 @@ fn test_system(plugin: &mut SimplePlugin, game: &mut Game) {
                 .finish();
         }
     }
-    for (entity, (position, _cow)) in game.query::<(&Position, &Cow)>() {
-        entity.set(Position {
-            y: position.y + 0.1,
-            ..position
-        });
+    for (_, (mut position, _)) in game.query::<(&mut Position, &Cow)>() {
+        position.y += 0.1;
     }
+
     plugin.tick_counter += 1;
 }
 


### PR DESCRIPTION
# Query with mutable borrows

## Status

- [X] Ready 
- [ ] Development
- [ ] Hold

## Description

Adds the ability to perform `for (entity, (mut position, cow)) in game.query::<(&mut Position, &Cow)>` within plugins.

### Implementation
 
 This PR adds a `Query` impl for `&'a mut T` alongside the existing implementation for `&'a T`.   

Additionally, it adds `borrowed_mut` to `Query` to indicate if a `HostComponent` is borrowed mutably within the `Query`.   
This is combined in the tuple query, and then at iterator creation it counts each instance of `HostComponent` within the `Query`'s list of components and ensures if one is found more than once that that component is not borrowed mutably. 

### Notable Changes

Quill's `Entity::set` has been changed to `Entity::insert` because its primary purpose is no longer updating a component on an entity.

## Notes for the future

- We should examine the performance effects and correctness impacts of queuing up query mutations and submit them to the host in bulk.
- We may want to support nesting queries in the future, this solution will not comply with that. This can be trivially worked around for now, and we can examine supporting nesting in the future. This will require a more elaborate borrow checker, which is why I'm avoiding it for now.

## Note for reviewers

Is this solution 100% perfect and awesome? No. There are definite improvements we could make sometime in the future but for now this is an entirely reasonable step in that direction. Any future changes won't cause backwards incompatibility, so its safe to put them off for the future. Its important that we get feather moving forward so we shouldn't seek absolute perfection for this feature.

## Checklist

- [X] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [X] Removed unnecessary commented out code
- [ ] ~~Used specific traces (if you trace actions please specify the cause i.e. the player)~~
