### PR TITLE
Added Sprint Tracking

### DIFF
--- a/feather/common/src/entities/player.rs
+++ b/feather/common/src/entities/player.rs
@@ -2,7 +2,7 @@ use anyhow::bail;
 use base::EntityKind;
 use ecs::{EntityBuilder, SysResult};
 use quill_common::{
-    components::{CreativeFlying, Sneaking},
+    components::{CreativeFlying, Sneaking, Sprinting},
     entities::Player,
 };
 
@@ -12,6 +12,7 @@ pub fn build_default(builder: &mut EntityBuilder) {
         .add(Player)
         .add(CreativeFlying(false))
         .add(Sneaking(false))
+        .add(Sprinting(false))
         .add(EntityKind::Player);
 }
 

--- a/feather/server/src/packet_handlers/entity_action.rs
+++ b/feather/server/src/packet_handlers/entity_action.rs
@@ -1,7 +1,10 @@
 use common::Game;
 use ecs::{Entity, SysResult};
 use protocol::packets::client::{EntityAction, EntityActionKind};
-use quill_common::{components::Sneaking, events::SneakEvent};
+use quill_common::{
+    components::{Sneaking, Sprinting},
+    events::{SneakEvent, SprintEvent},
+};
 
 ///  From [wiki](https://wiki.vg/Protocol#Entity_Action)
 ///  Sent by the client to indicate that it has performed certain actions:
@@ -36,10 +39,20 @@ pub fn handle_entity_action(game: &mut Game, player: Entity, packet: EntityActio
             // a notice that bed state might have changed.
         }
         EntityActionKind::StartSprinting => {
-            //TODO issue #423
+            let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
+            if !is_sprinting {
+                game.ecs
+                    .insert_entity_event(player, SprintEvent::new(true))?;
+                game.ecs.get_mut::<Sprinting>(player)?.0 = true;
+            }
         }
         EntityActionKind::StopSprinting => {
-            //TODO issue #423
+            let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
+            if is_sprinting {
+                game.ecs
+                    .insert_entity_event(player, SprintEvent::new(false))?;
+                game.ecs.get_mut::<Sprinting>(player)?.0 = false;
+            }
         }
         EntityActionKind::StartHorseJump => {
             //TODO issue #423

--- a/feather/server/src/packet_handlers/entity_action.rs
+++ b/feather/server/src/packet_handlers/entity_action.rs
@@ -38,20 +38,13 @@ pub fn handle_entity_action(game: &mut Game, player: Entity, packet: EntityActio
             // and all players are kicked out of the bed. We have to seperatly send out
             // a notice that bed state might have changed.
         }
-        EntityActionKind::StartSprinting => {
+        EntityActionKind::StartSprinting | EntityActionKind::StopSprinting => {
+            let start_sprinting = matches!(EntityActionKind::StartSprinting, packet.action_id);
             let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
-            if !is_sprinting {
+            if is_sprinting != start_sprinting {
                 game.ecs
-                    .insert_entity_event(player, SprintEvent::new(true))?;
-                game.ecs.get_mut::<Sprinting>(player)?.0 = true;
-            }
-        }
-        EntityActionKind::StopSprinting => {
-            let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
-            if is_sprinting {
-                game.ecs
-                    .insert_entity_event(player, SprintEvent::new(false))?;
-                game.ecs.get_mut::<Sprinting>(player)?.0 = false;
+                    .insert_entity_event(player, SprintEvent::new(start_sprinting))?;
+                game.ecs.get_mut::<Sprinting>(player)?.0 = start_sprinting;
             }
         }
         EntityActionKind::StartHorseJump => {

--- a/feather/server/src/packet_handlers/entity_action.rs
+++ b/feather/server/src/packet_handlers/entity_action.rs
@@ -38,20 +38,13 @@ pub fn handle_entity_action(game: &mut Game, player: Entity, packet: EntityActio
             // and all players are kicked out of the bed. We have to seperatly send out
             // a notice that bed state might have changed.
         }
-        EntityActionKind::StartSprinting => {
+        EntityActionKind::StartSprinting | EntityActionKind::StopSprinting => {
+            let start_sprinting = matches!(packet.action_id, EntityActionKind::StartSprinting);
             let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
-            if !is_sprinting {
+            if is_sprinting != start_sprinting {
                 game.ecs
-                    .insert_entity_event(player, SprintEvent::new(true))?;
-                game.ecs.get_mut::<Sprinting>(player)?.0 = true;
-            }
-        }
-        EntityActionKind::StopSprinting => {
-            let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
-            if is_sprinting {
-                game.ecs
-                    .insert_entity_event(player, SprintEvent::new(false))?;
-                game.ecs.get_mut::<Sprinting>(player)?.0 = false;
+                    .insert_entity_event(player, SprintEvent::new(start_sprinting))?;
+                game.ecs.get_mut::<Sprinting>(player)?.0 = start_sprinting;
             }
         }
         EntityActionKind::StartHorseJump => {

--- a/feather/server/src/packet_handlers/entity_action.rs
+++ b/feather/server/src/packet_handlers/entity_action.rs
@@ -38,13 +38,20 @@ pub fn handle_entity_action(game: &mut Game, player: Entity, packet: EntityActio
             // and all players are kicked out of the bed. We have to seperatly send out
             // a notice that bed state might have changed.
         }
-        EntityActionKind::StartSprinting | EntityActionKind::StopSprinting => {
-            let start_sprinting = matches!(EntityActionKind::StartSprinting, packet.action_id);
+        EntityActionKind::StartSprinting => {
             let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
-            if is_sprinting != start_sprinting {
+            if !is_sprinting {
                 game.ecs
-                    .insert_entity_event(player, SprintEvent::new(start_sprinting))?;
-                game.ecs.get_mut::<Sprinting>(player)?.0 = start_sprinting;
+                    .insert_entity_event(player, SprintEvent::new(true))?;
+                game.ecs.get_mut::<Sprinting>(player)?.0 = true;
+            }
+        }
+        EntityActionKind::StopSprinting => {
+            let is_sprinting = game.ecs.get_mut::<Sprinting>(player)?.0;
+            if is_sprinting {
+                game.ecs
+                    .insert_entity_event(player, SprintEvent::new(false))?;
+                game.ecs.get_mut::<Sprinting>(player)?.0 = false;
             }
         }
         EntityActionKind::StartHorseJump => {

--- a/quill/common/src/component.rs
+++ b/quill/common/src/component.rs
@@ -188,6 +188,8 @@ host_component_enum! {
         CreativeFlyingEvent = 1010,
         Sneaking = 1011,
         SneakEvent = 1012,
+        Sprinting = 1013,
+        SprintEvent = 1014,
 
 
     }
@@ -352,3 +354,4 @@ bincode_component_impl!(BlockPlacementEvent);
 bincode_component_impl!(BlockInteractEvent);
 bincode_component_impl!(CreativeFlyingEvent);
 bincode_component_impl!(SneakEvent);
+bincode_component_impl!(SprintEvent);

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -110,8 +110,8 @@ bincode_component_impl!(CreativeFlying);
 pub struct Sneaking(pub bool);
 bincode_component_impl!(Sneaking);
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// A component on players that tracks if they are sprinting or not.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Sprinting(pub bool);
 impl Sprinting {
     pub fn new(value: bool) -> Self {

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -109,3 +109,13 @@ bincode_component_impl!(CreativeFlying);
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Sneaking(pub bool);
 bincode_component_impl!(Sneaking);
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// A component on players that tracks if they are sprinting or not.
+pub struct Sprinting(pub bool);
+impl Sprinting {
+    pub fn new(value: bool) -> Self {
+        Sprinting(value)
+    }
+}
+bincode_component_impl!(Sprinting);

--- a/quill/common/src/events.rs
+++ b/quill/common/src/events.rs
@@ -3,5 +3,5 @@ mod change;
 mod interact_entity;
 
 pub use block_interact::{BlockInteractEvent, BlockPlacementEvent};
-pub use change::{CreativeFlyingEvent, SneakEvent};
+pub use change::{CreativeFlyingEvent, SneakEvent, SprintEvent};
 pub use interact_entity::InteractEntityEvent;

--- a/quill/common/src/events/change.rs
+++ b/quill/common/src/events/change.rs
@@ -29,3 +29,16 @@ impl SneakEvent {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SprintEvent {
+    pub is_sprinting: bool,
+}
+
+impl SprintEvent {
+    pub fn new(changed_to: bool) -> Self {
+        Self {
+            is_sprinting: changed_to,
+        }
+    }
+}

--- a/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
+++ b/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
@@ -4,6 +4,7 @@ flying.
 */
 
 use quill::{
+    components::Sprinting,
     events::{CreativeFlyingEvent, SneakEvent},
     Game, Plugin, Setup,
 };
@@ -16,6 +17,7 @@ impl Plugin for FlightPlugin {
     fn enable(_game: &mut Game, setup: &mut Setup<Self>) -> Self {
         setup.add_system(flight_observer_system);
         setup.add_system(sneak_observer_system);
+        setup.add_system(sprinting_observer_system);
         FlightPlugin {}
     }
 
@@ -38,6 +40,14 @@ fn sneak_observer_system(_plugin: &mut FlightPlugin, game: &mut Game) {
             player.send_message("Enjoy sneaking!");
         } else {
             player.send_message("How was it to be sneaking?");
+        }
+    }
+}
+
+fn sprinting_observer_system(_plugin: &mut FlightPlugin, game: &mut Game) {
+    for (player, sprinting) in game.query::<&Sprinting>() {
+        if sprinting.0 {
+            player.send_message("Are you sprinting?");
         }
     }
 }


### PR DESCRIPTION
# Added Sprint Tracking

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Did the same as #428 just for sprinting instead.

## Related issues

#423 

## Checklist
Note: Could not test plugin because of a potential compiler bug in Rust version 1.52.1

- [x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)
