### PR TITLE
Made it so quill::Plugin does not have to be in scope for plugins.

### DIFF
--- a/quill/api/src/lib.rs
+++ b/quill/api/src/lib.rs
@@ -94,10 +94,11 @@ macro_rules! plugin {
         #[doc(hidden)]
         #[cfg(target_arch = "wasm32")]
         pub unsafe extern "C" fn quill_setup() {
-            let plugin = $plugin::enable(&mut $crate::Game::new(), &mut $crate::Setup::new());
+            let plugin: $plugin =
+                quill::Plugin::enable(&mut $crate::Game::new(), &mut $crate::Setup::new());
             PLUGIN = Some(plugin);
         }
-
+        
         #[no_mangle]
         #[doc(hidden)]
         #[cfg(not(target_arch = "wasm32"))]

--- a/quill/api/src/lib.rs
+++ b/quill/api/src/lib.rs
@@ -115,7 +115,8 @@ macro_rules! plugin {
             $crate::sys::init_host_vtable(&vtable)
                 .expect("invalid vtable (check that the plugin and host are up to date)");
 
-            let plugin = $plugin::enable(&mut $crate::Game::new(), &mut $crate::Setup::new());
+            let plugin: $plugin =
+                quill::Plugin::enable(&mut $crate::Game::new(), &mut $crate::Setup::new());
             PLUGIN = Some(plugin);
         }
 


### PR DESCRIPTION
# Small fix for plugins.

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description
The following code used to not compile, because quill::Plugin was not in scope. Now it does.
```rust
pub struct CommandPlugin {}

quill::plugin!(CommandPlugin);

impl quill::Plugin  for CommandPlugin {
    fn enable(game: &mut quill::Game, setup: &mut quill::Setup<Self>) -> Self {
        CommandPlugin{}
    }

    fn disable(self, game: &mut quill::Game) {
        todo!()
    }
}
```
I modified the quill::plugin! macro to not rely on quill::Plugin to be in scope. 


## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)
