### PR TITLE
Update GLOBAL_BITS_PER_BLOCK and HIGHEST_ID

### DIFF
--- a/feather/base/src/chunk.rs
+++ b/feather/base/src/chunk.rs
@@ -1,6 +1,6 @@
 use std::usize;
 
-use ::blocks::{BlockId, HIGHEST_ID};
+use ::blocks::BlockId;
 
 use generated::Biome;
 
@@ -376,6 +376,7 @@ impl ChunkSection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::HIGHEST_ID;
 
     #[test]
     fn chunk_new() {

--- a/feather/base/src/chunk.rs
+++ b/feather/base/src/chunk.rs
@@ -1,13 +1,14 @@
 use std::usize;
 
-use ::blocks::BlockId;
+use ::blocks::{BlockId, HIGHEST_ID};
+
 use generated::Biome;
 
 use crate::ChunkPosition;
 
 /// The number of bits used for each block
 /// in the global palette.
-pub const GLOBAL_BITS_PER_BLOCK: u8 = 14;
+pub const GLOBAL_BITS_PER_BLOCK: u8 = 15;
 
 /// The minimum bits per block allowed when
 /// using a section palette.
@@ -604,5 +605,11 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn global_bits() {
+        //The highest block state id must fit into GLOBAL_BITS_PER_BLOCK
+        assert_eq!(HIGHEST_ID >> GLOBAL_BITS_PER_BLOCK, 0)
     }
 }

--- a/feather/base/src/chunk.rs
+++ b/feather/base/src/chunk.rs
@@ -1,7 +1,6 @@
 use std::usize;
 
 use ::blocks::BlockId;
-
 use generated::Biome;
 
 use crate::ChunkPosition;

--- a/feather/blocks/src/lib.rs
+++ b/feather/blocks/src/lib.rs
@@ -21,7 +21,7 @@ static VANILLA_ID_TABLE: Lazy<Vec<Vec<u16>>> = Lazy::new(|| {
     bincode::deserialize(bytes).expect("failed to deserialize generated vanilla ID table (bincode)")
 });
 
-const HIGHEST_ID: u16 = 8596;
+pub const HIGHEST_ID: u16 = 17111;
 
 static FROM_VANILLA_ID_TABLE: Lazy<Vec<BlockId>> = Lazy::new(|| {
     let mut res = vec![BlockId::default(); u16::max_value() as usize];
@@ -169,6 +169,14 @@ mod tests {
 
         block.set_instrument(Instrument::Basedrum);
         assert_eq!(block.instrument(), Some(Instrument::Basedrum));
+    }
+
+    #[test]
+    fn highest_id() {
+        assert_eq!(
+            HIGHEST_ID,
+            *VANILLA_ID_TABLE.last().unwrap().last().unwrap()
+        )
     }
 
     #[test]


### PR DESCRIPTION
# Update GLOBAL_BITS_PER_BLOCK and HIGHEST_ID

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

- Increases the GLOBAL_BITS_PER_BLOCK to 15 in order to match the current [chunk format]https://wiki.vg/Chunk_Format#Tips_and_notes). Without this, the client gets sent incorrect chunk data if the chunk section uses the global palette.

- Adds a small test that makes sure that HIGHEST_ID fits in the bits specified by GLOBAL_BITS_PER_BLOCK, to prevent this in the future.
- Increases HIGHEST_ID to the current highest id and adds a test for it.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)
