### PR TITLE
Health and Fall damage systems

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ The component can then be accessed both from Feather and from plugins.
 In Feather, events are components. An entity with the `PlayerJoinEvent` component just joined
 the game, for example.
 
-The event sytsem serves as a mechanism to communicate between different crates and modules.
+The event system serves as a mechanism to communicate between different crates and modules.
 For example, triggering a `BlockChangeEvent` _anywhere_ causes `feather-server` to send block
 update packets to players.
 

--- a/feather/common/src/game.rs
+++ b/feather/common/src/game.rs
@@ -2,10 +2,10 @@ use std::{cell::RefCell, mem, rc::Rc, sync::Arc};
 
 use base::{BlockId, BlockPosition, ChunkPosition, Position, Text, Title};
 use ecs::{
-    Ecs, Entity, EntityBuilder, HasEcs, HasResources, NoSuchEntity, Resources, SysResult,
-    SystemExecutor,
+    Ecs, Entity, EntityBuilder, EntityRef, HasEcs, HasResources, NoSuchEntity, Resources,
+    SysResult, SystemExecutor,
 };
-use quill_common::{entities::Player, entity_init::EntityInit};
+use quill_common::{components::Health, entities::Player, entity_init::EntityInit};
 
 use crate::{
     chat::{ChatKind, ChatMessage},
@@ -228,6 +228,13 @@ impl Game {
     /// necessary block updates.
     pub fn break_block(&mut self, pos: BlockPosition) -> bool {
         self.set_block(pos, BlockId::air())
+    }
+
+    pub fn reset_player(&self, player: EntityRef) {
+        match player.get_mut::<Health>() {
+            Ok(mut health) => *health = Health::new(20),
+            Err(_) => (),
+        }
     }
 }
 

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -15,7 +15,9 @@ use common::{
     Window,
 };
 use flume::{Receiver, Sender};
-use packets::server::{Particle, SetSlot, SpawnLivingEntity, UpdateLight, WindowConfirmation};
+use packets::server::{
+    Particle, Respawn, SetSlot, SpawnLivingEntity, UpdateHealth, UpdateLight, WindowConfirmation,
+};
 use protocol::{
     packets::{
         self,
@@ -28,7 +30,7 @@ use protocol::{
     },
     ClientPlayPacket, Nbt, ProtocolVersion, ServerPlayPacket, Writeable,
 };
-use quill_common::components::OnGround;
+use quill_common::components::{Health, Hunger, OnGround};
 use uuid::Uuid;
 use vec_arena::Arena;
 
@@ -488,6 +490,34 @@ impl Client {
             window_id: 0,
             slot,
             slot_data: item,
+        });
+    }
+
+    pub fn update_health(&self, player_health: &Health) {
+        let player_hunger = Hunger::new();
+
+        self.send_packet(UpdateHealth {
+            health: player_health.health as f32,
+            food: player_hunger.food as i32,
+            food_saturation: player_hunger.saturation as f32,
+        });
+    }
+
+    pub fn respawn_player(&self, gamemode: Gamemode) {
+        let dimension = nbt::Blob::from_reader(&mut Cursor::new(include_bytes!(
+            "../../../assets/dimension.nbt"
+        )))
+        .expect("dimenstion asset is malformed");
+
+        self.send_packet(Respawn {
+            dimension: Nbt(dimension),
+            world_name: "world".to_owned(),
+            hashed_seed: 0,
+            gamemode,
+            previous_gamemode: Gamemode::Survival,
+            is_debug: false,
+            is_flat: false,
+            copy_metadata: false,
         });
     }
 

--- a/feather/server/src/entities.rs
+++ b/feather/server/src/entities.rs
@@ -26,6 +26,7 @@ pub fn add_entity_components(builder: &mut EntityBuilder, init: &EntityInit) {
         builder.add(NetworkId::new());
     }
     builder.add(PreviousPosition(*builder.get::<Position>().unwrap()));
+    builder.add(FallDistance(0.0));
     add_spawn_packet(builder, init);
 }
 
@@ -57,3 +58,8 @@ fn spawn_living_entity(entity: &EntityRef, client: &Client) -> SysResult {
     client.send_living_entity(network_id, uuid, pos, kind);
     Ok(())
 }
+
+/// Increasing distance of an entity falling. Used to calculate
+/// fall damage for entities with health.
+#[derive(Copy, Clone, Debug)]
+pub struct FallDistance(pub f64);

--- a/feather/server/src/packet_handlers.rs
+++ b/feather/server/src/packet_handlers.rs
@@ -17,6 +17,7 @@ use quill_common::components::Name;
 use crate::{NetworkId, Server};
 
 mod entity_action;
+mod health;
 mod interaction;
 pub mod inventory;
 mod movement;
@@ -75,10 +76,13 @@ pub fn handle_packet(
             entity_action::handle_entity_action(game, player_id, packet)
         }
 
+        ClientPlayPacket::ClientStatus(packet) => {
+            health::handle_client_status(game, server, player_id, packet)
+        }
+
         ClientPlayPacket::TeleportConfirm(_)
         | ClientPlayPacket::QueryBlockNbt(_)
         | ClientPlayPacket::SetDifficulty(_)
-        | ClientPlayPacket::ClientStatus(_)
         | ClientPlayPacket::TabComplete(_)
         | ClientPlayPacket::WindowConfirmation(_)
         | ClientPlayPacket::ClickWindowButton(_)

--- a/feather/server/src/packet_handlers/health.rs
+++ b/feather/server/src/packet_handlers/health.rs
@@ -1,0 +1,27 @@
+use crate::{ClientId, Server};
+use base::Gamemode;
+use common::Game;
+use ecs::{Entity, SysResult};
+use protocol::packets::client::ClientStatus;
+
+pub fn handle_client_status(
+    game: &mut Game,
+    server: &mut Server,
+    player_id: Entity,
+    packet: ClientStatus,
+) -> SysResult {
+    match packet {
+        ClientStatus::PerformRespawn => {
+            let client_id = game.ecs.get::<ClientId>(player_id).unwrap();
+            let client = server.clients.get(*client_id).unwrap();
+
+            client.respawn_player(Gamemode::Survival);
+
+            let player = game.ecs.entity(player_id)?;
+            game.reset_player(player);
+        }
+        ClientStatus::RequestStats => {}
+    }
+
+    Ok(())
+}

--- a/feather/server/src/systems.rs
+++ b/feather/server/src/systems.rs
@@ -3,6 +3,8 @@
 mod block;
 mod chat;
 mod entity;
+mod falldamage;
+mod health;
 mod particle;
 mod player_join;
 mod player_leave;
@@ -32,10 +34,13 @@ pub fn register(server: Server, game: &mut Game, systems: &mut SystemExecutor<Ga
     player_leave::register(systems);
     tablist::register(systems);
     block::register(systems);
+
+    // Falldamage must be processed before PreviousPosition is updated (entity).
+    falldamage::register(game, systems);
     entity::register(game, systems);
     chat::register(game, systems);
     particle::register(systems);
-    plugin_message::register(systems);
+    health::register(game, systems);
 
     systems.group::<Server>().add_system(tick_clients);
 }

--- a/feather/server/src/systems.rs
+++ b/feather/server/src/systems.rs
@@ -40,6 +40,7 @@ pub fn register(server: Server, game: &mut Game, systems: &mut SystemExecutor<Ga
     entity::register(game, systems);
     chat::register(game, systems);
     particle::register(systems);
+    plugin_message::register(systems);
     health::register(game, systems);
 
     systems.group::<Server>().add_system(tick_clients);

--- a/feather/server/src/systems/falldamage.rs
+++ b/feather/server/src/systems/falldamage.rs
@@ -1,0 +1,49 @@
+use crate::{
+    entities::{FallDistance, PreviousPosition},
+    Game, Server,
+};
+use base::Position;
+use ecs::{SysResult, SystemExecutor};
+use quill_common::components::{Health, OnGround};
+
+pub fn register(_: &mut Game, systems: &mut SystemExecutor<Game>) {
+    systems.group::<Server>().add_system(calculate_falldamage);
+}
+
+fn calculate_falldamage(game: &mut Game, _: &mut Server) -> SysResult {
+    for (_, (position, prev_position, on_ground, fall_distance, health)) in game
+        .ecs
+        .query::<(
+            &Position,
+            &PreviousPosition,
+            &OnGround,
+            &mut FallDistance,
+            &mut Health,
+        )>()
+        .iter()
+    {
+        match on_ground.0 {
+            false => {
+                let new_distance = prev_position.0.y - position.y;
+
+                fall_distance.0 += new_distance.abs();
+            }
+            // Apply fall damage.
+            true => {
+                let damage = (fall_distance.0.ceil() as u32).saturating_sub(3);
+
+                health.deal_damage(damage);
+
+                #[cfg(debug_assertions)]
+                if fall_distance.0 > 0.0 {
+                    log::debug!("Entity fell {:?} ({:?} damage)", fall_distance, damage);
+                }
+
+                // Reset fall distance.
+                fall_distance.0 = 0.0;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/feather/server/src/systems/falldamage.rs
+++ b/feather/server/src/systems/falldamage.rs
@@ -26,7 +26,7 @@ fn calculate_falldamage(game: &mut Game, _: &mut Server) -> SysResult {
             false => {
                 let new_distance = prev_position.0.y - position.y;
 
-                fall_distance.0 += new_distance.abs();
+                fall_distance.0 += new_distance;
             }
             // Apply fall damage.
             true => {

--- a/feather/server/src/systems/health.rs
+++ b/feather/server/src/systems/health.rs
@@ -1,0 +1,18 @@
+use crate::{client::ClientId, Game, Server};
+use ecs::{SysResult, SystemExecutor};
+
+use quill_common::components::Health;
+
+pub fn register(_: &mut Game, systems: &mut SystemExecutor<Game>) {
+    systems.group::<Server>().add_system(update_health);
+}
+
+fn update_health(game: &mut Game, server: &mut Server) -> SysResult {
+    for (_, (client_id, health)) in game.ecs.query::<(&ClientId, &mut Health)>().iter() {
+        if let Some(client) = server.clients.get(*client_id) {
+            client.update_health(&health);
+        }
+    }
+
+    Ok(())
+}

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -143,9 +143,12 @@ impl Health {
         self.health = self.health.saturating_sub(damage);
     }
 
-    /// TODO
-    pub fn regenerate() {
-        todo!()
+    /// Increase the health to at most `max_health` of `Health`.
+    pub fn regenerate(&mut self, health: u32) {
+        self.health = match self.health + health {
+            health if health > self.max_health => self.max_health,
+            health => health,
+        }
     }
 }
 

--- a/quill/common/src/components.rs
+++ b/quill/common/src/components.rs
@@ -119,3 +119,46 @@ impl Sprinting {
     }
 }
 bincode_component_impl!(Sprinting);
+
+/// An entity's health.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Health {
+    pub health: u32,
+    pub max_health: u32,
+}
+
+impl Health {
+    /// Creates a new `Health` object with both health
+    /// and max_health initialized to the given value.
+    pub fn new(max_health: u32) -> Self {
+        Self {
+            health: max_health,
+            max_health,
+        }
+    }
+
+    /// Reduce the health by at most the amount `damage`. If
+    /// the subtraction would underflow, health is set to 0.
+    pub fn deal_damage(&mut self, damage: u32) {
+        self.health = self.health.saturating_sub(damage);
+    }
+
+    /// TODO
+    pub fn regenerate() {
+        todo!()
+    }
+}
+
+pub struct Hunger {
+    pub food: u32,
+    pub saturation: u32,
+}
+
+impl Hunger {
+    pub fn new() -> Self {
+        Self {
+            food: 20,
+            saturation: 5,
+        }
+    }
+}


### PR DESCRIPTION
# Health and Fall damage systems

## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

Adds Health and Hunger components. Adds a health and fall damage system.

## Related issues

 #358

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.