### PR TITLE
Fix compilation on latest nightly

### DIFF
--- a/feather/worldgen/src/superflat.rs
+++ b/feather/worldgen/src/superflat.rs
@@ -22,9 +22,8 @@ impl WorldGenerator for SuperflatWorldGenerator {
             if layer.height == 0 {
                 continue;
             }
-            // FIXME: get rid of this hack by having a constistent naming convention - Item::name() returns `stone` but BlockId::from_identifier requires `minecraft:stone`
-            let layer_block =
-                BlockId::from_identifier(("minecraft:".to_owned() + &layer.block).as_str());
+            // FIXME: get rid of this hack by having a consistent naming convention - Item::name() returns `stone` but BlockId::from_identifier requires `minecraft:stone`
+            let layer_block = BlockId::from_identifier(&format!("minecraft:{}", layer.block));
             if let Some(layer_block) = layer_block {
                 for y in y_counter..(y_counter + layer.height) {
                     for x in 0..16 {


### PR DESCRIPTION
# Fix compilation on latest nightly

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

I don't know why, but GitHub Actions for #458 fails (where I didn't even change this file), and that's a fix. Also fixes a typo.

## Related issues

#458 

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.