### PR TITLE
Fix cache mismatch between x86-darwin and aarch64-darwin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: ${{ matrix.target }}
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -135,8 +139,6 @@ jobs:
           echo "SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)" >> $GITHUB_ENV
         if: matrix.target == 'aarch64-apple-darwin'
-
-      - uses: Swatinem/rust-cache@v1
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: ${{ matrix.target }}
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
# Fix cache mismatch between x86-darwin and aarch64-darwin

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

_Short description what you did and/or fixed_

## Related issues

_Leave empty if none_

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.