### PR TITLE
Fix double creation of network IDs for players

### DIFF
--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -134,6 +134,10 @@ impl Client {
         &self.profile
     }
 
+    pub fn network_id(&self) -> Option<NetworkId> {
+        self.network_id
+    }
+
     pub fn uuid(&self) -> Uuid {
         self.uuid
     }

--- a/feather/server/src/lib.rs
+++ b/feather/server/src/lib.rs
@@ -115,15 +115,9 @@ impl Server {
         }
     }
 
-    /// Allocates a `NetworkId` for an entity.
-    pub fn create_network_id(&mut self) -> NetworkId {
-        NetworkId::new()
-    }
-
     fn create_client(&mut self, player: NewPlayer) -> ClientId {
         log::debug!("Creating client for {}", player.username);
-        let network_id = self.create_network_id();
-        let client = Client::new(player, Arc::clone(&self.options), network_id);
+        let client = Client::new(player, Arc::clone(&self.options));
         self.clients.insert(client)
     }
 


### PR DESCRIPTION
# Fix double creation of network IDs for players

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

The network ID for player is created twice: for entity (in spawn callback) and for client (in create_client), causing player network IDs to be 0, 2, 4 when rejoining. This PR fixes this so that network IDs are only created in entity spawn callback.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.