### PR TITLE
Fix update_entity_position and fix writing of Angles to client.

### DIFF
--- a/feather/protocol/src/io.rs
+++ b/feather/protocol/src/io.rs
@@ -833,7 +833,11 @@ impl Readable for Angle {
 
 impl Writeable for Angle {
     fn write(&self, buffer: &mut Vec<u8>, version: ProtocolVersion) -> anyhow::Result<()> {
-        let val = (self.0 / 360.0 * 256.0).round() as u8;
+        let temp = (256.0 / 360.0) * (self.0 % 360.0);
+        // Wrap negative values 'x' in the range [-256.0 to 0] to the
+        // correct angle in the range [0 to 256.0 ) by changing 'x' to
+        // x = 256.0 - x
+        let val = ((temp + 256.0) % 256.0) as u8;
         val.write(buffer, version)?;
 
         Ok(())

--- a/feather/server/src/systems/entity.rs
+++ b/feather/server/src/systems/entity.rs
@@ -24,7 +24,7 @@ fn send_entity_movement(game: &mut Game, server: &mut Server) -> SysResult {
     {
         if position != prev_position.0 {
             server.broadcast_nearby_with(position, |client| {
-                client.update_entity_position(network_id, position, on_ground);
+                client.update_entity_position(network_id, position, *prev_position, on_ground);
             });
             prev_position.0 = position;
         }


### PR DESCRIPTION
# Fix update_entity_position and fix writing of Angles to client.

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

update_entity_position to use both `EntityPosition` and `EntityPositionAndRotation` instead of `EntityTeleport` packet.
Also only sends `EntityPositionAndRotation` if there was a rotation.

The `Writable` implementation for `Angle` was broken before and if you moved in either direction too far it would get stuck on 255. This also solves that. Credits to @Miro-Andrin for coming up with the math.

## Related issues


## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.