### PR TITLE
Entity sneak and sprint

### DIFF
--- a/feather/base/src/metadata.rs
+++ b/feather/base/src/metadata.rs
@@ -20,7 +20,7 @@ pub const META_INDEX_IS_CUSTOM_NAME_VISIBLE: u8 = 3;
 pub const META_INDEX_IS_SILENT: u8 = 4;
 pub const META_INDEX_NO_GRAVITY: u8 = 5;
 
-pub const META_INDEX_ITEM_SLOT: u8 = 6;
+pub const META_INDEX_POSE: u8 = 6;
 
 pub const META_INDEX_FALLING_BLOCK_SPAWN_POSITION: u8 = 7;
 
@@ -82,6 +82,30 @@ impl MetaEntry {
             MetaEntry::OptVarInt(_) => 17,
             MetaEntry::Pose(_) => 18,
         }
+    }
+}
+
+pub enum Pose {
+    Standing,
+    FallFlying,
+    Sleeping,
+    Swimming,
+    SpinAttack,
+    Sneaking,
+    Dying,
+}
+
+impl ToMetaEntry for Pose {
+    fn to_meta_entry(&self) -> MetaEntry {
+        MetaEntry::Pose(match self {
+            Self::Standing => 0,
+            Self::FallFlying => 1,
+            Self::Sleeping => 2,
+            Self::Swimming => 3,
+            Self::SpinAttack => 4,
+            Self::Sneaking => 5,
+            Self::Dying => 6,
+        })
     }
 }
 

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -547,6 +547,16 @@ impl Client {
         });
     }
 
+    pub fn send_entity_metadata(&self, network_id: NetworkId, metadata: EntityMetadata) {
+        if self.network_id().unwrap() == network_id {
+            return;
+        }
+        self.send_packet(SendEntityMetadata {
+            entity_id: network_id.0,
+            entries: metadata,
+        });
+    }
+
     pub fn send_abilities(&self, abilities: &base::anvil::player::PlayerAbilities) {
         let mut bitfield = 0;
         if *abilities.invulnerable {

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -548,7 +548,7 @@ impl Client {
     }
 
     pub fn send_entity_metadata(&self, network_id: NetworkId, metadata: EntityMetadata) {
-        if self.network_id().unwrap() == network_id {
+        if self.network_id == Some(network_id) {
             return;
         }
         self.send_packet(SendEntityMetadata {

--- a/feather/server/src/systems/entity.rs
+++ b/feather/server/src/systems/entity.rs
@@ -1,10 +1,16 @@
 //! Sends entity-related packets to clients.
 //! Spawn packets, position updates, equipment, animations, etc.
 
-use base::Position;
+use base::{
+    metadata::{EntityBitMask, Pose, META_INDEX_ENTITY_BITMASK, META_INDEX_POSE},
+    EntityMetadata, Position,
+};
 use common::Game;
 use ecs::{SysResult, SystemExecutor};
-use quill_common::components::OnGround;
+use quill_common::{
+    components::{OnGround, Sprinting},
+    events::{SneakEvent, SprintEvent},
+};
 
 use crate::{entities::PreviousPosition, NetworkId, Server};
 
@@ -12,7 +18,11 @@ mod spawn_packet;
 
 pub fn register(game: &mut Game, systems: &mut SystemExecutor<Game>) {
     spawn_packet::register(game, systems);
-    systems.group::<Server>().add_system(send_entity_movement);
+    systems
+        .group::<Server>()
+        .add_system(send_entity_movement)
+        .add_system(send_entity_sneak_metadata)
+        .add_system(send_entity_sprint_metadata);
 }
 
 /// Sends entity movement packets.
@@ -28,6 +38,54 @@ fn send_entity_movement(game: &mut Game, server: &mut Server) -> SysResult {
             });
             prev_position.0 = position;
         }
+    }
+    Ok(())
+}
+
+/// Sends [SendEntityMetadata](protocol::packets::server::play::SendEntityMetadata) packet for when an entity is sneaking.
+fn send_entity_sneak_metadata(game: &mut Game, server: &mut Server) -> SysResult {
+    for (_, (&position, &SneakEvent { is_sneaking }, is_sprinting, &network_id)) in game
+        .ecs
+        .query::<(&Position, &SneakEvent, &Sprinting, &NetworkId)>()
+        .iter()
+    {
+        let mut metadata = EntityMetadata::entity_base();
+        let mut bit_mask = EntityBitMask::empty();
+
+        // The Entity can sneak and sprint at the same time, what happens is that when it stops sneaking you immediately start running again.
+        bit_mask.set(EntityBitMask::CROUCHED, is_sneaking);
+        bit_mask.set(EntityBitMask::SPRINTING, is_sprinting.0);
+        metadata.set(META_INDEX_ENTITY_BITMASK, bit_mask.bits());
+
+        if is_sneaking {
+            metadata.set(META_INDEX_POSE, Pose::Sneaking);
+        } else {
+            metadata.set(META_INDEX_POSE, Pose::Standing);
+        }
+
+        server.broadcast_nearby_with(position, |client| {
+            client.send_entity_metadata(network_id, metadata.clone());
+        });
+    }
+    Ok(())
+}
+
+/// Sends [SendEntityMetadata](protocol::packets::server::play::SendEntityMetadata) packet for when an entity is sprinting.
+fn send_entity_sprint_metadata(game: &mut Game, server: &mut Server) -> SysResult {
+    for (_, (&position, &SprintEvent { is_sprinting }, &network_id)) in game
+        .ecs
+        .query::<(&Position, &SprintEvent, &NetworkId)>()
+        .iter()
+    {
+        let mut metadata = EntityMetadata::entity_base();
+        let mut bit_mask = EntityBitMask::empty();
+
+        bit_mask.set(EntityBitMask::SPRINTING, is_sprinting);
+        metadata.set(META_INDEX_ENTITY_BITMASK, bit_mask.bits());
+
+        server.broadcast_nearby_with(position, |client| {
+            client.send_entity_metadata(network_id, metadata.clone());
+        });
     }
     Ok(())
 }


### PR DESCRIPTION
# Add Entity Sneaking and Sprinting for other clients.

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Added 2 new systems that send a `EntityMetadata` packet, that tells clients that a certain entity is sneaking or sprinting.
Added pose Enum to EntityMetadata, also changed Const name to better fit.
Added a `send_entity_metadata` to client.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.