### PR TITLE
Entity equipment 

### DIFF
--- a/feather/protocol/src/packets/server/play.rs
+++ b/feather/protocol/src/packets/server/play.rs
@@ -947,7 +947,7 @@ packets! {
 #[derive(Debug, Clone)]
 pub struct EntityEquipment {
     pub entity_id: i32,
-    pub entries: Vec<EquipmentEntry>,
+    pub entries: Vec<EquipmentEntry>, // cannot be empty (if nothing is equipped, send an empty main hand)
 }
 
 impl Readable for EntityEquipment {

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -27,7 +27,7 @@ use protocol::{
         self,
         server::{
             AddPlayer, Animation, BlockChange, ChatPosition, ChunkData, ChunkDataKind,
-            DestroyEntities, Disconnect, EntityAnimation, EntityHeadLook, JoinGame, KeepAlive,
+            DestroyEntities, Disconnect, EntityAnimation, EntityEquipment, EntityHeadLook, EquipmentEntry, JoinGame, KeepAlive,
             PlayerInfo, PlayerPositionAndLook, PluginMessage, SendEntityMetadata, SpawnPlayer,
             Title, UnloadChunk, UpdateViewPosition, WindowItems,
         },
@@ -539,11 +539,11 @@ impl Client {
         self.set_slot(-1, item);
     }
 
-    pub fn send_player_model_flags(&self, netowrk_id: NetworkId, model_flags: u8) {
+    pub fn send_player_model_flags(&self, network_id: NetworkId, model_flags: u8) {
         let mut entity_metadata = EntityMetadata::new();
         entity_metadata.set(16, model_flags);
         self.send_packet(SendEntityMetadata {
-            entity_id: netowrk_id.0,
+            entity_id: network_id.0,
             entries: entity_metadata,
         });
     }
@@ -556,6 +556,13 @@ impl Client {
             entity_id: network_id.0,
             entries: metadata,
         });
+    }
+
+    pub fn send_entity_equipment(&self, network_id: NetworkId, equipment: Vec<EquipmentEntry>) {
+        self.send_packet(EntityEquipment {
+            entity_id: network_id.0,
+            entries: equipment,
+        })
     }
 
     pub fn send_abilities(&self, abilities: &base::anvil::player::PlayerAbilities) {


### PR DESCRIPTION
# Entity equipment

## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description
This PR implements entity equipment packets (i.e. armor, items in the main hand and off-hand).

## Related issues
#494

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.