### PR TITLE
Use `IpAddr` instead of `Ipv4Addr`

### DIFF
--- a/feather/server/src/config.rs
+++ b/feather/server/src/config.rs
@@ -1,6 +1,6 @@
 //! Loads an `Options` from a TOML config.
 
-use std::{fs, net::Ipv4Addr, path::Path, str::FromStr};
+use std::{fs, net::IpAddr, path::Path, str::FromStr};
 
 use anyhow::Context;
 use base::Gamemode;
@@ -78,7 +78,7 @@ impl Config {
 
 #[derive(Debug, Deserialize)]
 pub struct Network {
-    pub address: Ipv4Addr,
+    pub address: IpAddr,
     pub port: u16,
     pub compression_threshold: i32,
 }


### PR DESCRIPTION
## Description

Adds the ability to use the IPv6 addresses. Solves #496.


## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)