### PR TITLE
Set more sane default values for light levels

### DIFF
--- a/feather/base/src/chunk/light.rs
+++ b/feather/base/src/chunk/light.rs
@@ -16,14 +16,13 @@ impl Default for LightStore {
 }
 
 impl LightStore {
-    /// Creates a `LightStore` with all light set to 15.
+    /// Creates a `LightStore` with sky light set to 15.
     pub fn new() -> Self {
         let mut this = LightStore {
             block_light: PackedArray::new(SECTION_VOLUME, 4),
             sky_light: PackedArray::new(SECTION_VOLUME, 4),
         };
-        fill_with_default_light(&mut this.block_light);
-        fill_with_default_light(&mut this.sky_light);
+        this.sky_light.fill(15);
         this
     }
 
@@ -71,11 +70,5 @@ impl LightStore {
 
     pub fn sky_light(&self) -> &PackedArray {
         &self.sky_light
-    }
-}
-
-fn fill_with_default_light(arr: &mut PackedArray) {
-    for i in 0..arr.len() {
-        arr.set(i, 15);
     }
 }


### PR DESCRIPTION
# Set more sane default values for light levels

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Set block light level to 0 by default. Imo it's better than glowing terrain in the night for now.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] ~~Used specific traces (if you trace actions please specify the cause i.e. the player)~~

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.