### PR TITLE
Correctly specify packet for interaction (R-click) with an entity

### DIFF
--- a/feather/protocol/src/packets/client/play.rs
+++ b/feather/protocol/src/packets/client/play.rs
@@ -106,9 +106,9 @@ def_enum! {
         0 = Interact,
         1 = Attack,
         2 = InteractAt {
-            target_x f64;
-            target_y f64;
-            target_z f64;
+            target_x f32;
+            target_y f32;
+            target_z f32;
             hand VarInt;
         },
     }

--- a/feather/server/src/connection_worker.rs
+++ b/feather/server/src/connection_worker.rs
@@ -145,7 +145,6 @@ impl Worker {
         tokio::task::spawn(async move {
             let result = reader.race(writer).await.expect("task panicked");
             if let Err(e) = result {
-                log::trace!("Panic error is: {}", e);
                 let message = disconnected_message(e);
                 log::debug!("{} lost connection: {}", username, message);
             }

--- a/feather/server/src/connection_worker.rs
+++ b/feather/server/src/connection_worker.rs
@@ -145,6 +145,7 @@ impl Worker {
         tokio::task::spawn(async move {
             let result = reader.race(writer).await.expect("task panicked");
             if let Err(e) = result {
+                log::trace!("Panic error is: {}", e);
                 let message = disconnected_message(e);
                 log::debug!("{} lost connection: {}", username, message);
             }


### PR DESCRIPTION
# Correctly specify packet for interaction (R-click) with an entity

## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

An incorrect specification for the packet representing interaction (right-click)
from a player to an entity caused the server to crash.

This issue was fixed by changing the data types for the members of the packet representing the target position vectors.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.