### PR TITLE
Fix new clippy warnings from Rust 1.57.0

### DIFF
--- a/feather/common/src/window.rs
+++ b/feather/common/src/window.rs
@@ -196,7 +196,7 @@ impl Window {
     }
 
     fn shift_click_in_player_window(&mut self, slot: usize) -> SysResult {
-        let mut slot_item = &mut *self.inner.item(slot)?;
+        let slot_item = &mut *self.inner.item(slot)?;
 
         let (inventory, slot_area, _) = self.inner.index_to_slot(slot).unwrap();
         let areas_to_try = [
@@ -238,7 +238,7 @@ impl Window {
                 let mut i = 0;
                 while let Some(mut stack) = inventory.item(area, i) {
                     if stack.is_empty() {
-                        stack.merge(&mut slot_item);
+                        stack.merge(slot_item);
                     }
                     i += 1;
                 }

--- a/libcraft/text/src/text/markdown/lexer.rs
+++ b/libcraft/text/src/text/markdown/lexer.rs
@@ -139,7 +139,7 @@ impl<'a> InputIter for Tokens<'a> {
     where
         P: Fn(Self::Item) -> bool,
     {
-        self.tok.iter().position(|b| predicate(b))
+        self.tok.iter().position(predicate)
     }
 
     fn slice_index(&self, count: usize) -> Option<usize> {


### PR DESCRIPTION
# Fix new clippy warnings from Rust 1.57.0

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description
Fixed the issues that came up from running `cargo clippy --all-targets` on Rust 1.157.0

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.