### PR TITLE
Kick the player if the server is outdated

### DIFF
--- a/feather/server/src/initial_handler.rs
+++ b/feather/server/src/initial_handler.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 
 use self::proxy::ProxyData;
 
+const VERSION_STRING: &str = "1.16.5";
 const SERVER_NAME: &str = "Feather 1.16.5";
 const PROTOCOL_VERSION: i32 = 754;
 
@@ -63,11 +64,11 @@ pub async fn handle(worker: &mut Worker) -> anyhow::Result<InitialHandling> {
     match handshake.next_state {
         HandshakeState::Status => handle_status(worker).await,
         HandshakeState::Login => {
-            if handshake.protocol_version < PROTOCOL_VERSION {
+            if handshake.protocol_version != PROTOCOL_VERSION {
                 worker
                     .write(ServerLoginPacket::DisconnectLogin(DisconnectLogin {
                         reason: Text::from(
-                            "Invalid protocol! The server is running on version 1.16!",
+                            "Invalid protocol! The server is running on version {}!", VERSION_STRING
                         )
                         .to_string(),
                     }))


### PR DESCRIPTION
# Kick the player if the server is outdated

## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

_Short description what you did and/or fixed_

## Related issues

_Leave empty if none_

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.