### PR TITLE
Survival block breaking

### DIFF
--- a/feather/common/src/block_break.rs
+++ b/feather/common/src/block_break.rs
@@ -1,29 +1,35 @@
-use base::{ValidBlockPosition, ItemStack};
-use ecs::{SystemExecutor, SysResult, EntityBuilder};
+use base::{ItemStack, ValidBlockPosition};
+use ecs::{EntityBuilder, SysResult, SystemExecutor};
 use quill_common::entity_init::EntityInit;
+
+pub struct DestroyStateChange(pub ValidBlockPosition, pub u8);
 
 use crate::{Game, World};
 
 pub type BlockBreaker = Option<ActiveBlockBreaker>;
+#[derive(Clone, Copy)]
 pub struct ActiveBlockBreaker {
     pub position: ValidBlockPosition,
     pub drop_item: bool,
+    pub total_ticks: u32,
     pub ticks_remaining: u32,
 }
 impl ActiveBlockBreaker {
-    pub fn tick(&mut self) -> bool {
+    pub fn tick(&mut self) -> (bool, bool) {
+        let before = self.destroy_stage();
         self.ticks_remaining = self.ticks_remaining.saturating_sub(1);
-        self.ticks_remaining == 0
+        let after = self.destroy_stage();
+        (self.ticks_remaining == 0, before != after)
     }
     pub fn break_block(self, game: &mut Game) -> SysResult {
         let target_block = match game.block(self.position) {
             Some(b) => b,
-            None => anyhow::bail!("cannot break unloaded block")
+            None => anyhow::bail!("cannot break unloaded block"),
         };
         game.break_block(self.position);
         if let Some(_item_drop) = base::Item::from_name(target_block.kind().name()) {
             if !self.drop_item {
-                return Ok(())
+                return Ok(());
             }
             let mut item_entity = EntityBuilder::new();
             crate::entities::item::build_default(&mut item_entity);
@@ -32,13 +38,22 @@ impl ActiveBlockBreaker {
         }
         Ok(())
     }
-    pub fn new_player(_world: &mut World, block_pos: ValidBlockPosition, _mainhand: Option<&ItemStack>, _offhand: Option<&ItemStack>) -> Option<Self> {
+    pub fn new_player(
+        _world: &mut World,
+        block_pos: ValidBlockPosition,
+        _mainhand: Option<&ItemStack>,
+        _offhand: Option<&ItemStack>,
+    ) -> Option<Self> {
         // TODO
         Some(Self {
             position: block_pos,
             drop_item: true,
+            total_ticks: 20,
             ticks_remaining: 20,
         })
+    }
+    pub fn destroy_stage(&self) -> u8 {
+        9 - (self.ticks_remaining as f32 / self.total_ticks as f32 * 9.0).round() as u8
     }
 }
 
@@ -47,19 +62,38 @@ pub fn register(systems: &mut SystemExecutor<Game>) {
 }
 
 fn process_block_breaking(game: &mut Game) -> SysResult {
-    let  mut break_queue = vec![];
+    let mut break_queue = vec![];
+    let mut update_queue = vec![];
     for (entity, breaker) in game.ecs.query::<&mut BlockBreaker>().iter() {
         if let Some(active) = breaker {
-            if active.tick() {
+            let (break_block, update_stage) = active.tick();
+            if update_stage {
+                update_queue.push(entity);
+            }
+            if break_block {
                 break_queue.push(entity);
             }
         }
     }
+    for entity in update_queue {
+        let breaker = { game.ecs.get_mut::<BlockBreaker>(entity).unwrap().unwrap() };
+        game.ecs.insert_entity_event(
+            entity,
+            DestroyStateChange(breaker.position, breaker.destroy_stage()),
+        )?;
+    }
     for entity in break_queue.into_iter() {
         // Set block breakers to None
         let breaker = {
-            game.ecs.get_mut::<BlockBreaker>(entity)?.take().unwrap()
+            game.ecs
+                .get_mut::<BlockBreaker>(entity)
+                .unwrap()
+                .take()
+                .unwrap()
         };
+        game.ecs
+            .insert_entity_event(entity, DestroyStateChange(breaker.position, 10))
+            .unwrap();
         breaker.break_block(game)?;
     }
     Ok(())

--- a/feather/common/src/block_break.rs
+++ b/feather/common/src/block_break.rs
@@ -1,0 +1,66 @@
+use base::{ValidBlockPosition, ItemStack};
+use ecs::{SystemExecutor, SysResult, EntityBuilder};
+use quill_common::entity_init::EntityInit;
+
+use crate::{Game, World};
+
+pub type BlockBreaker = Option<ActiveBlockBreaker>;
+pub struct ActiveBlockBreaker {
+    pub position: ValidBlockPosition,
+    pub drop_item: bool,
+    pub ticks_remaining: u32,
+}
+impl ActiveBlockBreaker {
+    pub fn tick(&mut self) -> bool {
+        self.ticks_remaining = self.ticks_remaining.saturating_sub(1);
+        self.ticks_remaining == 0
+    }
+    pub fn break_block(self, game: &mut Game) -> SysResult {
+        let target_block = match game.block(self.position) {
+            Some(b) => b,
+            None => anyhow::bail!("cannot break unloaded block")
+        };
+        game.break_block(self.position);
+        if let Some(_item_drop) = base::Item::from_name(target_block.kind().name()) {
+            if !self.drop_item {
+                return Ok(())
+            }
+            let mut item_entity = EntityBuilder::new();
+            crate::entities::item::build_default(&mut item_entity);
+            let builder = game.create_entity_builder(self.position.position(), EntityInit::Item);
+            game.spawn_entity(builder);
+        }
+        Ok(())
+    }
+    pub fn new_player(_world: &mut World, block_pos: ValidBlockPosition, _mainhand: Option<&ItemStack>, _offhand: Option<&ItemStack>) -> Option<Self> {
+        // TODO
+        Some(Self {
+            position: block_pos,
+            drop_item: true,
+            ticks_remaining: 20,
+        })
+    }
+}
+
+pub fn register(systems: &mut SystemExecutor<Game>) {
+    systems.add_system(process_block_breaking);
+}
+
+fn process_block_breaking(game: &mut Game) -> SysResult {
+    let  mut break_queue = vec![];
+    for (entity, breaker) in game.ecs.query::<&mut BlockBreaker>().iter() {
+        if let Some(active) = breaker {
+            if active.tick() {
+                break_queue.push(entity);
+            }
+        }
+    }
+    for entity in break_queue.into_iter() {
+        // Set block breakers to None
+        let breaker = {
+            game.ecs.get_mut::<BlockBreaker>(entity)?.take().unwrap()
+        };
+        breaker.break_block(game)?;
+    }
+    Ok(())
+}

--- a/feather/common/src/lib.rs
+++ b/feather/common/src/lib.rs
@@ -32,12 +32,15 @@ pub mod entities;
 
 pub mod interactable;
 
+pub mod block_break;
+
 /// Registers gameplay systems with the given `Game` and `SystemExecutor`.
 pub fn register(game: &mut Game, systems: &mut SystemExecutor<Game>) {
     view::register(game, systems);
     chunk::loading::register(game, systems);
     chunk::entities::register(systems);
     interactable::register(game);
+    block_break::register(systems);
 
     game.add_entity_spawn_callback(entities::add_entity_components);
 }

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -20,7 +20,7 @@ use common::{
 use libcraft_items::InventorySlot;
 use packets::server::{Particle, SetSlot, SpawnLivingEntity, UpdateLight, WindowConfirmation};
 use protocol::packets::server::{
-    EntityPosition, EntityPositionAndRotation, EntityTeleport, HeldItemChange, PlayerAbilities,
+    EntityPosition, EntityPositionAndRotation, EntityTeleport, HeldItemChange, PlayerAbilities, PlayerDiggingStatus, AcknowledgePlayerDigging, BlockBreakAnimation,
 };
 use protocol::{
     packets::{
@@ -600,6 +600,23 @@ impl Client {
 
     pub fn set_hotbar_slot(&self, slot: u8) {
         self.send_packet(HeldItemChange { slot });
+    }
+
+    pub fn acknowledge_player_digging(&self, position: ValidBlockPosition, block: BlockId, status: PlayerDiggingStatus, successful: bool) {
+        self.send_packet(AcknowledgePlayerDigging {
+            position,
+            block,
+            status,
+            successful,
+        })
+    }
+
+    pub fn block_break_animation(&self, entity_id: i32, position: ValidBlockPosition, destroy_stage: u8) {
+        self.send_packet(BlockBreakAnimation {
+            entity_id,
+            position,
+            destroy_stage,
+        })
     }
 
     fn register_entity(&self, network_id: NetworkId) {

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -20,7 +20,8 @@ use common::{
 use libcraft_items::InventorySlot;
 use packets::server::{Particle, SetSlot, SpawnLivingEntity, UpdateLight, WindowConfirmation};
 use protocol::packets::server::{
-    EntityPosition, EntityPositionAndRotation, EntityTeleport, HeldItemChange, PlayerAbilities, PlayerDiggingStatus, AcknowledgePlayerDigging, BlockBreakAnimation,
+    AcknowledgePlayerDigging, BlockBreakAnimation, EntityPosition, EntityPositionAndRotation,
+    EntityTeleport, HeldItemChange, PlayerAbilities, PlayerDiggingStatus,
 };
 use protocol::{
     packets::{
@@ -602,7 +603,13 @@ impl Client {
         self.send_packet(HeldItemChange { slot });
     }
 
-    pub fn acknowledge_player_digging(&self, position: ValidBlockPosition, block: BlockId, status: PlayerDiggingStatus, successful: bool) {
+    pub fn acknowledge_player_digging(
+        &self,
+        position: ValidBlockPosition,
+        block: BlockId,
+        status: PlayerDiggingStatus,
+        successful: bool,
+    ) {
         self.send_packet(AcknowledgePlayerDigging {
             position,
             block,
@@ -611,9 +618,14 @@ impl Client {
         })
     }
 
-    pub fn block_break_animation(&self, entity_id: i32, position: ValidBlockPosition, destroy_stage: u8) {
+    pub fn block_break_animation(
+        &self,
+        entity_id: u32,
+        position: ValidBlockPosition,
+        destroy_stage: u8,
+    ) {
         self.send_packet(BlockBreakAnimation {
-            entity_id,
+            entity_id: i32::from_le_bytes(entity_id.to_le_bytes()),
             position,
             destroy_stage,
         })

--- a/feather/server/src/packet_handlers/interaction.rs
+++ b/feather/server/src/packet_handlers/interaction.rs
@@ -1,5 +1,7 @@
 use crate::{ClientId, NetworkId, Server};
+use base::Gamemode;
 use base::inventory::{SLOT_HOTBAR_OFFSET, SLOT_OFFHAND};
+use common::block_break::{BlockBreaker, ActiveBlockBreaker};
 use common::entities::player::HotbarSlot;
 use common::interactable::InteractableRegistry;
 use common::{Game, Window};
@@ -119,8 +121,32 @@ pub fn handle_player_digging(
 ) -> SysResult {
     log::trace!("Got player digging with status {:?}", packet.status);
     match packet.status {
-        PlayerDiggingStatus::StartDigging | PlayerDiggingStatus::CancelDigging => {
-            game.break_block(packet.position);
+        PlayerDiggingStatus::StartDigging => {
+            if matches!(*game.ecs.get::<Gamemode>(player)?, Gamemode::Creative | Gamemode::Spectator) {
+                game.break_block(packet.position);
+            } else {
+                let mut breaker = game.ecs.get_mut::<BlockBreaker>(player)?;
+                let window = game.ecs.get::<Window>(player)?;
+                let hotbar_slot = game.ecs.get::<HotbarSlot>(player)?.get();
+                let main = window.item(SLOT_HOTBAR_OFFSET + hotbar_slot)?;
+                let offh = window.item(SLOT_OFFHAND)?;
+                let _ = breaker.insert(ActiveBlockBreaker::new_player(&mut game.world, packet.position, main.item_stack(), offh.item_stack()).unwrap());
+            }
+
+            Ok(())
+        },
+        PlayerDiggingStatus::CancelDigging => {
+            game.ecs.get_mut::<BlockBreaker>(player)?.take();
+            let client = server.clients.get(*game.ecs.get(player)?).unwrap();
+            let block = match game.block(packet.position) { Some(s)=>s,None=>return Ok(())};
+            client.acknowledge_player_digging(packet.position, block, protocol::packets::server::PlayerDiggingStatus::Cancelled, false);
+            Ok(())
+        },
+        PlayerDiggingStatus::FinishDigging => {
+            let success = game.ecs.get::<BlockBreaker>(player)?.is_some();
+            let client = server.clients.get(*game.ecs.get(player)?).unwrap();
+            let block = match game.block(packet.position) { Some(s)=>s,None=>return Ok(())};
+            client.acknowledge_player_digging(packet.position, block, protocol::packets::server::PlayerDiggingStatus::Finished, success);
             Ok(())
         }
         PlayerDiggingStatus::SwapItemInHand => {
@@ -145,7 +171,10 @@ pub fn handle_player_digging(
 
             Ok(())
         }
-        _ => Ok(()),
+        PlayerDiggingStatus::DropItemStack => Ok(()),
+        PlayerDiggingStatus::DropItem => Ok(()),
+        PlayerDiggingStatus::ShootArrow => Ok(()),
+        
     }
 }
 

--- a/feather/server/src/packet_handlers/interaction.rs
+++ b/feather/server/src/packet_handlers/interaction.rs
@@ -131,14 +131,12 @@ pub fn handle_player_digging(
                 let mut breaker = game.ecs.get_mut::<BlockBreaker>(player)?;
                 let window = game.ecs.get::<Window>(player)?;
                 let hotbar_slot = game.ecs.get::<HotbarSlot>(player)?.get();
-                let main = window.item(SLOT_HOTBAR_OFFSET + hotbar_slot)?;
-                let offh = window.item(SLOT_OFFHAND)?;
+                let main_hand = window.item(SLOT_HOTBAR_OFFSET + hotbar_slot)?;
                 let _ = breaker.insert(
                     ActiveBlockBreaker::new_player(
                         &mut game.world,
                         packet.position,
-                        main.item_stack(),
-                        offh.item_stack(),
+                        main_hand.item_stack(),
                     )
                     .unwrap(),
                 );

--- a/feather/server/src/systems/player_join.rs
+++ b/feather/server/src/systems/player_join.rs
@@ -109,7 +109,7 @@ fn accept_new_player(game: &mut Game, server: &mut Server, client_id: ClientId) 
             Position::default().chunk(),
             server.options.view_distance,
         ))
-        .add(Gamemode::Survival)
+        .add(Gamemode::Creative)
         .add(previous_gamemode)
         .add(Name::new(client.username()))
         .add(client.uuid())

--- a/feather/server/src/systems/player_join.rs
+++ b/feather/server/src/systems/player_join.rs
@@ -1,3 +1,4 @@
+use common::block_break::BlockBreaker;
 use libcraft_items::InventorySlot;
 use log::debug;
 
@@ -108,7 +109,7 @@ fn accept_new_player(game: &mut Game, server: &mut Server, client_id: ClientId) 
             Position::default().chunk(),
             server.options.view_distance,
         ))
-        .add(gamemode)
+        .add(Gamemode::Survival)
         .add(previous_gamemode)
         .add(Name::new(client.username()))
         .add(client.uuid())
@@ -123,6 +124,7 @@ fn accept_new_player(game: &mut Game, server: &mut Server, client_id: ClientId) 
                 .map(|data| data.animal.health)
                 .unwrap_or(20.0),
         ))
+        .add(BlockBreaker::None)
         .add(abilities.walk_speed)
         .add(abilities.fly_speed)
         .add(abilities.is_flying)

--- a/feather/server/src/systems/player_join.rs
+++ b/feather/server/src/systems/player_join.rs
@@ -124,7 +124,7 @@ fn accept_new_player(game: &mut Game, server: &mut Server, client_id: ClientId) 
                 .map(|data| data.animal.health)
                 .unwrap_or(20.0),
         ))
-        .add(BlockBreaker::None)
+        .add(BlockBreaker::Inactive)
         .add(abilities.walk_speed)
         .add(abilities.fly_speed)
         .add(abilities.is_flying)

--- a/libcraft/items/src/inventory_slot.rs
+++ b/libcraft/items/src/inventory_slot.rs
@@ -188,6 +188,20 @@ impl InventorySlot {
             InventorySlot::Empty => None,
         }
     }
+
+    pub fn item_stack(&self) -> Option<&ItemStack> {
+        match self {
+            InventorySlot::Filled(f) => Some(f),
+            InventorySlot::Empty => None,
+        }
+    }
+
+    pub fn item_stack_mut(&mut self) -> Option<&mut ItemStack> {
+        match self {
+            InventorySlot::Filled(f) => Some(f),
+            InventorySlot::Empty => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/libcraft/items/src/item_stack.rs
+++ b/libcraft/items/src/item_stack.rs
@@ -324,6 +324,10 @@ impl ItemStack {
     pub fn stack_size(&self) -> u32 {
         self.item.stack_size()
     }
+
+    pub fn metadata(&self) -> Option<&ItemStackMeta> {
+        self.meta.as_ref()
+    }
 }
 
 /// An error type that may be returned when performing
@@ -354,6 +358,12 @@ impl ItemStackMeta {
             repair_cost: None,
             enchantments: vec![],
         }
+    }
+    pub fn enchantments(&self) -> &[Enchantment] {
+        &self.enchantments
+    }
+    pub fn enchantments_mut(&mut self) -> &mut Vec<Enchantment> {
+        &mut self.enchantments
     }
 }
 


### PR DESCRIPTION
# Implementing breaking blocks in survival

## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

The goal of this PR is to implement the survival mining mechanic. This depends on potion effects (haste and mining fatigue) and physics (player in water/flying). The blocks currently do not drop items on the ground, nor does mining decrease durability.

I believe that the related issues can be resolved at a later time, simply because mining is an integral part of the game and works well enough without these features.

## Related issues

Original issue #351
Potion effects #430
Physics #357

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)