### PR TITLE
Fix `LevelData::generator_type` function

### DIFF
--- a/feather/base/src/anvil/level.rs
+++ b/feather/base/src/anvil/level.rs
@@ -164,7 +164,7 @@ impl LevelData {
         match self.generator_name.to_lowercase().as_str() {
             "default" => LevelGeneratorType::Default,
             "flat" => LevelGeneratorType::Flat,
-            "largeBiomes" => LevelGeneratorType::LargeBiomes,
+            "largebiomes" => LevelGeneratorType::LargeBiomes,
             "amplified" => LevelGeneratorType::Amplified,
             "buffet" => LevelGeneratorType::Buffet,
             "debug_all_block_states" => LevelGeneratorType::Debug,


### PR DESCRIPTION
# Fix `LevelData::generator_type` function

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Fix `LevelData::generator_type` by making it so that `LevelGeneratorType::LargeBiomes` can also be returned as this was not possible before due to the string literal being lowercased.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.