### PR TITLE
Add plugins/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 world/
 /config.toml
+plugins/
 
 # Python cache files (libcraft)
 **/__pycache__/


### PR DESCRIPTION
# Add plugins/ to .gitignore

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

This PR adds plugins/ to .gitignore.

## Related issues

None

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.