### PR TITLE
Change Title's inner value and message type to `Text`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "quill-common",
  "quill-plugin-format",
  "serde",
+ "serde_json",
  "tempfile",
  "vec-arena",
  "wasmer",
@@ -2070,6 +2071,7 @@ dependencies = [
  "libcraft-text",
  "quill-common",
  "quill-sys",
+ "serde_json",
  "thiserror",
  "uuid",
 ]

--- a/feather/plugin-host/Cargo.toml
+++ b/feather/plugin-host/Cargo.toml
@@ -25,6 +25,7 @@ tempfile = "3"
 vec-arena = "1"
 wasmer = { version = "2", default-features = false, features = [ "jit" ] }
 wasmer-wasi = { version = "2", default-features = false, features = [ "host-fs", "sys" ] }
+serde_json = "1"
 
 [features]
 llvm = [ "wasmer/llvm" ]

--- a/feather/plugin-host/src/context.rs
+++ b/feather/plugin-host/src/context.rs
@@ -328,6 +328,20 @@ impl PluginContext {
         }
     }
 
+    /// Accesses a `json`-encoded value in the plugin's memory space.
+    pub fn read_json<T: DeserializeOwned>(
+        &self,
+        ptr: PluginPtr<u8>,
+        len: u32,
+    ) -> anyhow::Result<T> {
+        // SAFETY: we do not return a reference to these
+        // bytes.
+        unsafe {
+            let bytes = self.deref_bytes(ptr.cast(), len)?;
+            serde_json::from_slice(bytes).map_err(From::from)
+        }
+    }
+
     /// Deserializes a component value in the plugin's memory space.
     pub fn read_component<T: Component>(&self, ptr: PluginPtr<u8>, len: u32) -> anyhow::Result<T> {
         // SAFETY: we do not return a reference to these

--- a/feather/plugin-host/src/host_calls/entity.rs
+++ b/feather/plugin-host/src/host_calls/entity.rs
@@ -17,12 +17,11 @@ pub fn entity_send_message(
     message_ptr: PluginPtr<u8>,
     message_len: u32,
 ) -> anyhow::Result<()> {
-    let message = cx.read_string(message_ptr, message_len)?;
+    let message = cx.read_json(message_ptr, message_len)?;
     let entity = Entity::from_bits(entity);
-    let _ = cx.game_mut().send_message(
-        entity,
-        ChatMessage::new(ChatKind::System, Text::from(message)),
-    );
+    let _ = cx
+        .game_mut()
+        .send_message(entity, ChatMessage::new(ChatKind::System, message));
     Ok(())
 }
 
@@ -33,7 +32,7 @@ pub fn entity_send_title(
     title_ptr: PluginPtr<u8>,
     title_len: u32,
 ) -> anyhow::Result<()> {
-    let title = cx.read_bincode(title_ptr, title_len)?;
+    let title = cx.read_json(title_ptr, title_len)?;
     let entity = Entity::from_bits(entity);
     cx.game_mut().send_title(entity, title);
     Ok(())

--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -480,11 +480,15 @@ impl Client {
             self.send_packet(Title::Reset);
         } else {
             if let Some(main_title) = title.title {
-                self.send_packet(Title::SetTitle { text: main_title });
+                self.send_packet(Title::SetTitle {
+                    text: main_title.to_string(),
+                });
             }
 
             if let Some(sub_title) = title.sub_title {
-                self.send_packet(Title::SetSubtitle { text: sub_title })
+                self.send_packet(Title::SetSubtitle {
+                    text: sub_title.to_string(),
+                })
             }
 
             self.send_packet(Title::SetTimesAndDisplay {

--- a/libcraft/text/src/title.rs
+++ b/libcraft/text/src/title.rs
@@ -1,10 +1,11 @@
+use crate::Text;
 use serde::{Deserialize, Serialize};
 
 // Based on https://wiki.vg/index.php?title=Protocol&oldid=16459#Title
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct Title {
-    pub title: Option<String>,
-    pub sub_title: Option<String>,
+    pub title: Option<Text>,
+    pub sub_title: Option<Text>,
     pub fade_in: u32,
     pub stay: u32,
     pub fade_out: u32,

--- a/quill/api/Cargo.toml
+++ b/quill/api/Cargo.toml
@@ -16,4 +16,5 @@ quill-common = { path = "../common" }
 thiserror = "1"
 uuid = "0.8"
 itertools = "0.10.0"
+serde_json = "1"
 

--- a/quill/api/src/entity.rs
+++ b/quill/api/src/entity.rs
@@ -1,3 +1,4 @@
+use libcraft_text::Text;
 use std::{marker::PhantomData, ptr};
 
 use quill_common::{Component, Pointer, PointerMut};
@@ -92,8 +93,8 @@ impl Entity {
     ///
     /// The message sends as a "system" message.
     /// See [the wiki](https://wiki.vg/Chat) for more details.
-    pub fn send_message(&self, message: impl AsRef<str>) {
-        let message = message.as_ref();
+    pub fn send_message(&self, message: impl Into<Text>) {
+        let message = message.into().to_string();
         unsafe {
             quill_sys::entity_send_message(self.id.0, message.as_ptr().into(), message.len() as u32)
         }
@@ -101,7 +102,7 @@ impl Entity {
 
     /// Sends the given title to this entity.
     pub fn send_title(&self, title: &libcraft_text::Title) {
-        let title = bincode::serialize(title).expect("failed to serialize Title");
+        let title = serde_json::to_string(title).expect("failed to serialize Title");
         unsafe {
             quill_sys::entity_send_title(self.id.0, title.as_ptr().into(), title.len() as u32);
         }

--- a/quill/example-plugins/titles/src/lib.rs
+++ b/quill/example-plugins/titles/src/lib.rs
@@ -28,8 +28,8 @@ fn title_system(plugin: &mut TitleExample, game: &mut Game) {
 
         // Create a title to send to the player
         let title = Title {
-            title: Some(Text::from(title_component).to_string()),
-            sub_title: Some(Text::from(component).to_string()),
+            title: Some(Text::from(title_component)),
+            sub_title: Some(Text::from(component)),
             fade_in: 5,
             stay: 400,
             fade_out: 5,

--- a/quill/sys/src/lib.rs
+++ b/quill/sys/src/lib.rs
@@ -97,7 +97,7 @@ extern "C" {
     /// The given `Title` should contain at least a `title` or a `sub_title`
     ///
     /// Does nothing if the entity does not exist or if it does not have the `Chat` component.
-    pub fn entity_send_title(entity: EntityId, title_ptr: Pointer<u8>, title_len: u32);
+    pub fn entity_send_title(entity: EntityId, title_json_ptr: Pointer<u8>, title_len: u32);
 
     /// Creates an empty entity builder.
     ///


### PR DESCRIPTION
# Change Title's inner value and message type to `Text`

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

This PR changes `Title` to use `Text` instead of json-serialized `String` and messages to use `Text` instead of raw `String`, adds a new quill->host serialization method (json). This change was made because bincode ^1 doesn't support `deserialize_any` but `Text` is an untagged enum and requires `deserialize_any`.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.