### PR TITLE
Add empty world generator as a config option

### DIFF
--- a/feather/server/config.toml
+++ b/feather/server/config.toml
@@ -31,7 +31,7 @@ hash = ""
 # The name of the directory containing the world.
 name = "world"
 # The generator to use if the world does not exist.
-# Implemented values are: default, flat
+# Implemented values are: default, flat, empty
 generator = "default"
 # The seed to use if the world does not exist.
 # Leaving this value empty will generate a random seed.

--- a/feather/server/config.toml
+++ b/feather/server/config.toml
@@ -31,7 +31,7 @@ hash = ""
 # The name of the directory containing the world.
 name = "world"
 # The generator to use if the world does not exist.
-# Implemented values are: default, flat, empty
+# Implemented values are: default, flat, void
 generator = "default"
 # The seed to use if the world does not exist.
 # Leaving this value empty will generate a random seed.

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -6,7 +6,7 @@ use common::{Game, TickLoop, World};
 use ecs::SystemExecutor;
 use feather_server::{config::Config, Server};
 use plugin_host::PluginManager;
-use worldgen::{ComposableGenerator, SuperflatWorldGenerator, WorldGenerator};
+use worldgen::{ComposableGenerator, EmptyWorldGenerator, SuperflatWorldGenerator, WorldGenerator};
 
 mod logging;
 
@@ -70,6 +70,7 @@ fn init_world_source(game: &mut Game, config: &Config) {
         "flat" => Arc::new(SuperflatWorldGenerator::new(
             SuperflatGeneratorOptions::default(),
         )),
+        "empty" => Arc::new(EmptyWorldGenerator),
         _ => Arc::new(ComposableGenerator::default_with_seed(seed)),
     };
     game.world = World::with_gen_and_path(generator, config.world.name.clone());

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -6,7 +6,7 @@ use common::{Game, TickLoop, World};
 use ecs::SystemExecutor;
 use feather_server::{config::Config, Server};
 use plugin_host::PluginManager;
-use worldgen::{ComposableGenerator, EmptyWorldGenerator, SuperflatWorldGenerator, WorldGenerator};
+use worldgen::{ComposableGenerator, VoidWorldGenerator, SuperflatWorldGenerator, WorldGenerator};
 
 mod logging;
 
@@ -70,7 +70,7 @@ fn init_world_source(game: &mut Game, config: &Config) {
         "flat" => Arc::new(SuperflatWorldGenerator::new(
             SuperflatGeneratorOptions::default(),
         )),
-        "empty" => Arc::new(EmptyWorldGenerator),
+        "void" => Arc::new(VoidWorldGenerator),
         _ => Arc::new(ComposableGenerator::default_with_seed(seed)),
     };
     game.world = World::with_gen_and_path(generator, config.world.name.clone());

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -6,7 +6,7 @@ use common::{Game, TickLoop, World};
 use ecs::SystemExecutor;
 use feather_server::{config::Config, Server};
 use plugin_host::PluginManager;
-use worldgen::{ComposableGenerator, VoidWorldGenerator, SuperflatWorldGenerator, WorldGenerator};
+use worldgen::{ComposableGenerator, SuperflatWorldGenerator, VoidWorldGenerator, WorldGenerator};
 
 mod logging;
 

--- a/feather/worldgen/src/lib.rs
+++ b/feather/worldgen/src/lib.rs
@@ -41,9 +41,9 @@ pub trait WorldGenerator: Send + Sync {
     fn generate_chunk(&self, position: ChunkPosition) -> Chunk;
 }
 
-pub struct EmptyWorldGenerator;
+pub struct VoidWorldGenerator;
 
-impl WorldGenerator for EmptyWorldGenerator {
+impl WorldGenerator for VoidWorldGenerator {
     fn generate_chunk(&self, position: ChunkPosition) -> Chunk {
         Chunk::new(position)
     }
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     pub fn test_worldgen_empty() {
         let chunk_pos = ChunkPosition { x: 1, z: 2 };
-        let generator = EmptyWorldGenerator;
+        let generator = VoidWorldGenerator;
         let chunk = generator.generate_chunk(chunk_pos);
 
         // No sections have been generated

--- a/feather/worldgen/src/lib.rs
+++ b/feather/worldgen/src/lib.rs
@@ -408,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_worldgen_empty() {
+    pub fn test_worldgen_void() {
         let chunk_pos = ChunkPosition { x: 1, z: 2 };
         let generator = VoidWorldGenerator;
         let chunk = generator.generate_chunk(chunk_pos);

--- a/feather/worldgen/src/lib.rs
+++ b/feather/worldgen/src/lib.rs
@@ -41,7 +41,7 @@ pub trait WorldGenerator: Send + Sync {
     fn generate_chunk(&self, position: ChunkPosition) -> Chunk;
 }
 
-pub struct EmptyWorldGenerator {}
+pub struct EmptyWorldGenerator;
 
 impl WorldGenerator for EmptyWorldGenerator {
     fn generate_chunk(&self, position: ChunkPosition) -> Chunk {

--- a/feather/worldgen/src/lib.rs
+++ b/feather/worldgen/src/lib.rs
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     pub fn test_worldgen_empty() {
         let chunk_pos = ChunkPosition { x: 1, z: 2 };
-        let generator = EmptyWorldGenerator {};
+        let generator = EmptyWorldGenerator;
         let chunk = generator.generate_chunk(chunk_pos);
 
         // No sections have been generated


### PR DESCRIPTION
# Add empty world generator as a config option

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.