### PR TITLE
Move PlayerJoinEvent, EntityRemoveEvent and EntityCreateEvent to quill-common

### DIFF
--- a/feather/common/src/chunk/entities.rs
+++ b/feather/common/src/chunk/entities.rs
@@ -1,12 +1,10 @@
 use ahash::AHashMap;
 use base::{ChunkPosition, Position};
 use ecs::{Entity, SysResult, SystemExecutor};
+use quill_common::events::{EntityCreateEvent, EntityRemoveEvent};
 use utils::vec_remove_item;
 
-use crate::{
-    events::{ChunkCrossEvent, EntityCreateEvent, EntityRemoveEvent},
-    Game,
-};
+use crate::{events::ChunkCrossEvent, Game};
 
 pub fn register(systems: &mut SystemExecutor<Game>) {
     systems.add_system(update_chunk_entities);

--- a/feather/common/src/chunk/loading.rs
+++ b/feather/common/src/chunk/loading.rs
@@ -9,13 +9,10 @@ use std::{
 use ahash::AHashMap;
 use base::ChunkPosition;
 use ecs::{Entity, SysResult, SystemExecutor};
+use quill_common::events::EntityRemoveEvent;
 use utils::vec_remove_item;
 
-use crate::{
-    chunk::worker::LoadRequest,
-    events::{EntityRemoveEvent, ViewUpdateEvent},
-    Game,
-};
+use crate::{chunk::worker::LoadRequest, events::ViewUpdateEvent, Game};
 
 pub fn register(game: &mut Game, systems: &mut SystemExecutor<Game>) {
     game.insert_resource(ChunkLoadState::default());

--- a/feather/common/src/events.rs
+++ b/feather/common/src/events.rs
@@ -8,10 +8,6 @@ mod plugin_message;
 pub use block_change::BlockChangeEvent;
 pub use plugin_message::PluginMessageEvent;
 
-/// Triggered when a player joins the `Game`.
-#[derive(Debug)]
-pub struct PlayerJoinEvent;
-
 /// Event triggered when a player changes their `View`,
 /// meaning they crossed into a new chunk.
 #[derive(Debug)]
@@ -62,14 +58,3 @@ pub struct ChunkLoadEvent {
 pub struct ChunkLoadFailEvent {
     pub position: ChunkPosition,
 }
-
-/// Triggered when an entity is removed from the world.
-///
-/// The entity will remain alive for one tick after it is
-/// destroyed to allow systems to observe this event.
-#[derive(Debug)]
-pub struct EntityRemoveEvent;
-
-/// Triggered when an entity is added into the world.
-#[derive(Debug)]
-pub struct EntityCreateEvent;

--- a/feather/common/src/game.rs
+++ b/feather/common/src/game.rs
@@ -5,12 +5,13 @@ use ecs::{
     Ecs, Entity, EntityBuilder, HasEcs, HasResources, NoSuchEntity, Resources, SysResult,
     SystemExecutor,
 };
+use quill_common::events::{EntityCreateEvent, EntityRemoveEvent, PlayerJoinEvent};
 use quill_common::{entities::Player, entity_init::EntityInit};
 
 use crate::{
     chat::{ChatKind, ChatMessage},
     chunk::entities::ChunkEntities,
-    events::{BlockChangeEvent, EntityCreateEvent, EntityRemoveEvent, PlayerJoinEvent},
+    events::BlockChangeEvent,
     ChatBox, World,
 };
 

--- a/feather/common/src/view.rs
+++ b/feather/common/src/view.rs
@@ -3,11 +3,9 @@ use base::{ChunkPosition, Position};
 use ecs::{SysResult, SystemExecutor};
 use itertools::Either;
 use quill_common::components::Name;
+use quill_common::events::PlayerJoinEvent;
 
-use crate::{
-    events::{PlayerJoinEvent, ViewUpdateEvent},
-    Game,
-};
+use crate::{events::ViewUpdateEvent, Game};
 
 /// Registers systems to update the `View` of a player.
 pub fn register(_game: &mut Game, systems: &mut SystemExecutor<Game>) {

--- a/feather/server/src/chunk_subscriptions.rs
+++ b/feather/server/src/chunk_subscriptions.rs
@@ -1,11 +1,8 @@
 use ahash::AHashMap;
 use base::ChunkPosition;
-use common::{
-    events::{EntityRemoveEvent, ViewUpdateEvent},
-    view::View,
-    Game,
-};
+use common::{events::ViewUpdateEvent, view::View, Game};
 use ecs::{SysResult, SystemExecutor};
+use quill_common::events::EntityRemoveEvent;
 use utils::vec_remove_item;
 
 use crate::{ClientId, Server};

--- a/feather/server/src/systems/entity/spawn_packet.rs
+++ b/feather/server/src/systems/entity/spawn_packet.rs
@@ -2,10 +2,11 @@ use ahash::AHashSet;
 use anyhow::Context;
 use base::Position;
 use common::{
-    events::{ChunkCrossEvent, EntityCreateEvent, EntityRemoveEvent, ViewUpdateEvent},
+    events::{ChunkCrossEvent, ViewUpdateEvent},
     Game,
 };
 use ecs::{SysResult, SystemExecutor};
+use quill_common::events::{EntityCreateEvent, EntityRemoveEvent};
 
 use crate::{entities::SpawnPacketSender, ClientId, NetworkId, Server};
 

--- a/feather/server/src/systems/tablist.rs
+++ b/feather/server/src/systems/tablist.rs
@@ -1,11 +1,9 @@
 //! Sends tablist info to clients via the Player Info packet.
 
 use base::{Gamemode, ProfileProperty};
-use common::{
-    events::{EntityRemoveEvent, PlayerJoinEvent},
-    Game,
-};
+use common::Game;
 use ecs::{SysResult, SystemExecutor};
+use quill_common::events::{EntityRemoveEvent, PlayerJoinEvent};
 use quill_common::{components::Name, entities::Player};
 use uuid::Uuid;
 

--- a/quill/common/src/component.rs
+++ b/quill/common/src/component.rs
@@ -198,8 +198,9 @@ host_component_enum! {
         CanBuild = 1020,
         Instabreak = 1021,
         Invulnerable = 1022,
-
-
+        PlayerJoinEvent = 1023,
+        EntityRemoveEvent = 1024,
+        EntityCreateEvent = 1025,
     }
 }
 
@@ -363,3 +364,6 @@ bincode_component_impl!(BlockInteractEvent);
 bincode_component_impl!(CreativeFlyingEvent);
 bincode_component_impl!(SneakEvent);
 bincode_component_impl!(SprintEvent);
+bincode_component_impl!(PlayerJoinEvent);
+bincode_component_impl!(EntityRemoveEvent);
+bincode_component_impl!(EntityCreateEvent);

--- a/quill/common/src/events.rs
+++ b/quill/common/src/events.rs
@@ -1,7 +1,9 @@
 mod block_interact;
 mod change;
+mod entity;
 mod interact_entity;
 
 pub use block_interact::{BlockInteractEvent, BlockPlacementEvent};
 pub use change::{CreativeFlyingEvent, SneakEvent, SprintEvent};
+pub use entity::{EntityCreateEvent, EntityRemoveEvent, PlayerJoinEvent};
 pub use interact_entity::InteractEntityEvent;

--- a/quill/common/src/events/entity.rs
+++ b/quill/common/src/events/entity.rs
@@ -1,16 +1,16 @@
 use serde::{Deserialize, Serialize};
 
 /// Triggered when a player joins the `Game`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PlayerJoinEvent;
 
 /// Triggered when an entity is removed from the world.
 ///
 /// The entity will remain alive for one tick after it is
 /// destroyed to allow systems to observe this event.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntityRemoveEvent;
 
 /// Triggered when an entity is added into the world.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EntityCreateEvent;

--- a/quill/common/src/events/entity.rs
+++ b/quill/common/src/events/entity.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+/// Triggered when a player joins the `Game`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PlayerJoinEvent;
+
+/// Triggered when an entity is removed from the world.
+///
+/// The entity will remain alive for one tick after it is
+/// destroyed to allow systems to observe this event.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EntityRemoveEvent;
+
+/// Triggered when an entity is added into the world.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EntityCreateEvent;


### PR DESCRIPTION
# Move PlayerJoinEvent, EntityRemoveEvent and EntityCreateEvent to quill-common

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.