### PR TITLE
Add events to quill API

### DIFF
--- a/quill/api/src/entity.rs
+++ b/quill/api/src/entity.rs
@@ -84,6 +84,26 @@ impl Entity {
                 host_component,
                 bytes.as_ptr().into(),
                 bytes.len() as u32,
+                0,
+            );
+        }
+    }
+
+    /// Inserts an event to the entity.
+    ///
+    /// If the entity already has this event,
+    /// the event is overwritten.
+    pub fn insert_event<T: Component>(&self, event: T) {
+        let host_component = T::host_component();
+        let bytes = event.to_cow_bytes();
+
+        unsafe {
+            quill_sys::entity_set_component(
+                self.id.0,
+                host_component,
+                bytes.as_ptr().into(),
+                bytes.len() as u32,
+                1,
             );
         }
     }

--- a/quill/api/src/game.rs
+++ b/quill/api/src/game.rs
@@ -4,6 +4,7 @@ use libcraft_blocks::BlockState;
 use libcraft_core::{BlockPosition, ChunkPosition, Position, CHUNK_HEIGHT};
 use libcraft_particles::Particle;
 use quill_common::entity_init::EntityInit;
+use quill_common::Component;
 
 use crate::{
     query::{Query, QueryIter},
@@ -216,6 +217,22 @@ impl Game {
                 data_ptr,
                 data.len() as u32,
             )
+        }
+    }
+
+    /// Inserts an event to the world.
+    pub fn insert_event<T: Component>(&self, event: T) {
+        let host_component = T::host_component();
+        let bytes = event.to_cow_bytes();
+
+        unsafe {
+            quill_sys::entity_set_component(
+                quill_common::entity::EntityId(0),
+                host_component,
+                bytes.as_ptr().into(),
+                bytes.len() as u32,
+                2,
+            );
         }
     }
 }

--- a/quill/api/src/query.rs
+++ b/quill/api/src/query.rs
@@ -265,6 +265,7 @@ impl<T: Component> std::ops::Drop for Mut<T> {
                 host_component,
                 bytes.as_ptr().into(),
                 bytes.len() as u32,
+                0,
             );
         }
     }

--- a/quill/sys/src/lib.rs
+++ b/quill/sys/src/lib.rs
@@ -75,14 +75,21 @@ extern "C" {
     /// `bytes_ptr` is a pointer to the serialized
     /// component.
     ///
+    /// Variant=0 will set the component.
     /// This will overwrite any existing component of the same type.
-    ///
     /// Does nothing if `entity` does not exist.
+    ///
+    /// Variant=1 will add the component as an entity event (the component will persist for 1 tick)
+    /// Does nothing if `entity` does not exist.
+    ///
+    /// Variant=2 will add the component as an event.
+    /// Doesn't use `entity` at all, but it's recommended to set it to 0.
     pub fn entity_set_component(
         entity: EntityId,
         component: HostComponent,
         bytes_ptr: Pointer<u8>,
         bytes_len: u32,
+        variant: u8,
     );
 
     /// Sends a message to an entity.


### PR DESCRIPTION
# Add events to quill API

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

This PR changes quill API to make `entity_set_component` host call accept a `variant: u8` param, 0 = insert component, 1 = insert entity event, 2 = insert event. Also adds `quill::Game::insert_event` and `quill::Entity::insert_event`

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.