### PR TITLE
Fixed quill's link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In the long term, Feather could be used on larger, more survival-like servers, w
 
 The Feather ecosystem consists of several repositories:
 * [`libcraft`](https://github.com/feather-rs/libcraft), a set of Rust crates providing Minecraft functionality.
-* [`quill`](https://github.com/feather-rs/quill), our work-in-progress plugin API. Quill plugins are written in Rust and compiled to WebAssembly. Feather runs them in a sandboxed WebAssembly VM.
+* [`quill`](https://github.com/feather-rs/feather/tree/main/quill), our work-in-progress plugin API. Quill plugins are written in Rust and compiled to WebAssembly. Feather runs them in a sandboxed WebAssembly VM.
 * `feather`, the server software built on top of `libcraft` and `quill`.
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In the long term, Feather could be used on larger, more survival-like servers, w
 ### Ecosystem
 
 The Feather ecosystem consists of several repositories:
-* [`libcraft`](https://github.com/feather-rs/libcraft), a set of Rust crates providing Minecraft functionality.
+* [`libcraft`](https://github.com/feather-rs/feather/tree/main/libcraft), a set of Rust crates providing Minecraft functionality.
 * [`quill`](https://github.com/feather-rs/feather/tree/main/quill), our work-in-progress plugin API. Quill plugins are written in Rust and compiled to WebAssembly. Feather runs them in a sandboxed WebAssembly VM.
 * `feather`, the server software built on top of `libcraft` and `quill`.
 


### PR DESCRIPTION
# Fixed quill's link in README.md

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

The link of quill in the readme.md points to the archived repo, fixed it to make it point to https://github.com/feather-rs/feather/tree/main/quill

## Related issues



## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.