### PR TITLE
Fixes wasi

### DIFF
--- a/feather/plugin-host/src/context/wasm/bump.rs
+++ b/feather/plugin-host/src/context/wasm/bump.rs
@@ -86,14 +86,12 @@ impl WasmBump {
         min_layout: Option<Layout>,
         previous_size: Option<usize>,
     ) -> anyhow::Result<Chunk> {
-        println!("barbar");
         let mut new_size = match previous_size {
             Some(previous_size) => previous_size
                 .checked_mul(2)
                 .context("chunk overflows usize")?,
             None => INITIAL_CHUNK_SIZE,
         };
-        println!("barbar");
         let mut align = CHUNK_ALIGN;
         if let Some(min_layout) = min_layout {
             align = align.max(min_layout.align());
@@ -101,17 +99,13 @@ impl WasmBump {
                 round_up_to(min_layout.size(), align).context("allocation too large")?;
             new_size = new_size.max(requested_size);
         }
-        println!("barbar");
         assert_eq!(align % CHUNK_ALIGN, 0);
         assert_eq!(new_size % CHUNK_ALIGN, 0);
         let layout = Layout::from_size_align(new_size, align).context("size or align is 0")?;
-        println!("barbar");
         assert!(new_size >= previous_size.unwrap_or(0) * 2);
-        println!("barbar");
         let start = self
             .allocate_function
             .call(layout.size() as u32, layout.align() as u32)?;
-        println!("barbar");
         Ok(Chunk {
             start,
             layout,

--- a/feather/plugin-host/src/context/wasm/bump.rs
+++ b/feather/plugin-host/src/context/wasm/bump.rs
@@ -40,8 +40,6 @@ impl WasmBump {
             deallocate_function,
             chunks: Vec::new(),
         };
-        let initial_chunk = this.allocate_chunk(None, None)?;
-        this.chunks.push(initial_chunk);
         Ok(this)
     }
 
@@ -88,13 +86,14 @@ impl WasmBump {
         min_layout: Option<Layout>,
         previous_size: Option<usize>,
     ) -> anyhow::Result<Chunk> {
+        println!("barbar");
         let mut new_size = match previous_size {
             Some(previous_size) => previous_size
                 .checked_mul(2)
                 .context("chunk overflows usize")?,
             None => INITIAL_CHUNK_SIZE,
         };
-
+        println!("barbar");
         let mut align = CHUNK_ALIGN;
         if let Some(min_layout) = min_layout {
             align = align.max(min_layout.align());
@@ -102,17 +101,17 @@ impl WasmBump {
                 round_up_to(min_layout.size(), align).context("allocation too large")?;
             new_size = new_size.max(requested_size);
         }
-
+        println!("barbar");
         assert_eq!(align % CHUNK_ALIGN, 0);
         assert_eq!(new_size % CHUNK_ALIGN, 0);
         let layout = Layout::from_size_align(new_size, align).context("size or align is 0")?;
-
+        println!("barbar");
         assert!(new_size >= previous_size.unwrap_or(0) * 2);
-
+        println!("barbar");
         let start = self
             .allocate_function
             .call(layout.size() as u32, layout.align() as u32)?;
-
+        println!("barbar");
         Ok(Chunk {
             start,
             layout,
@@ -124,7 +123,7 @@ impl WasmBump {
     /// all allocated memory.
     pub fn reset(&mut self) -> anyhow::Result<()> {
         // Free all but the last chunk.
-        for chunk in self.chunks.drain(..self.chunks.len() - 1) {
+        for chunk in self.chunks.drain(..self.chunks.len()) {
             self.deallocate_function.call(
                 chunk.start,
                 chunk.layout.size() as u32,
@@ -132,13 +131,9 @@ impl WasmBump {
             )?;
         }
 
-        assert_eq!(self.chunks.len(), 1);
-
-        // Reset the last chunk's data pointer.
-        let last_chunk = self.chunks.last_mut().unwrap();
-        last_chunk
-            .ptr
-            .set(last_chunk.start + last_chunk.layout.size() as u32);
+        // Allocate initial chunk
+        let chunk = self.allocate_chunk(None, None)?;
+        self.chunks.push(chunk);
 
         Ok(())
     }


### PR DESCRIPTION
# Fix wasi bug

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Fixes plugin issue with memory not being initialized on WasiEnv.

## Related issues

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.