### PR TITLE
Add logging filters for new wasmer-wasi logs

### DIFF
--- a/feather/server/src/logging.rs
+++ b/feather/server/src/logging.rs
@@ -39,6 +39,8 @@ pub fn init(level: LevelFilter) {
         // cranelift_codegen spams debug-level logs
         .level_for("cranelift_codegen", LevelFilter::Info)
         .level_for("regalloc", LevelFilter::Off)
+        .level_for("wasmer_wasi::syscalls", LevelFilter::Info)
+        .level_for("wasmer_compiler_cranelift::translator", LevelFilter::Warn)
         .chain(std::io::stdout())
         .apply()
         .unwrap();


### PR DESCRIPTION
# Add logging filters for new wasmer-wasi logs

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

For some reason the new version of wasmer-wasi spams INFO and DEBUG logs, this PR hides it.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.