### PR TITLE
Turned `quill::plugin` into a proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "plugin-macro"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "plugin-message"
 version = "0.1.0"
 dependencies = [
@@ -2068,6 +2076,7 @@ dependencies = [
  "libcraft-core",
  "libcraft-particles",
  "libcraft-text",
+ "plugin-macro",
  "quill-common",
  "quill-sys",
  "thiserror",
@@ -2807,9 +2816,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "quill/sys",
     "quill/common",
     "quill/api",
+    "quill/api/plugin-macro",
     "quill/plugin-format",
     "quill/cargo-quill",
 

--- a/quill/api/Cargo.toml
+++ b/quill/api/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+plugin-macro = { path = "./plugin-macro" }
 libcraft-core = { path = "../../libcraft/core" }
 libcraft-particles = { path = "../../libcraft/particles" }
 libcraft-blocks = { path = "../../libcraft/blocks" }

--- a/quill/api/plugin-macro/Cargo.toml
+++ b/quill/api/plugin-macro/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "plugin-macro"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.86", features = ["full"] }
+quote = "1.0.14"

--- a/quill/api/plugin-macro/src/lib.rs
+++ b/quill/api/plugin-macro/src/lib.rs
@@ -35,7 +35,7 @@ pub fn plugin(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let name = match input {
         Item::Enum(itm_enum) => itm_enum.ident,
         Item::Struct(itm_str) => itm_str.ident,
-        _ => panic!("Only structs or enums can be #[quill::plugin]!")
+        _ => panic!("Only structs or enums can be #[quill::plugin]!"),
     };
     let res = quote! {
         // `static mut` can be used without synchronization because the host
@@ -103,6 +103,6 @@ pub fn plugin(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
         fn main() {}
     };
     item.extend(TokenStream::from(res));
-    
+
     item
 }

--- a/quill/api/plugin-macro/src/lib.rs
+++ b/quill/api/plugin-macro/src/lib.rs
@@ -1,0 +1,108 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Item};
+
+/// Invoke this macro in your plugin's main.rs.
+///
+///  Give it the name of your struct implementing `Plugin`.
+///
+/// # Example
+/// ```ignore
+/// // main.rs
+/// use quill::{Plugin, Setup, Game};
+///
+/// #[quill::plugin]
+/// pub struct MyPlugin {
+///    // plugin state goes here
+/// }
+///
+/// impl Plugin for MyPlugin {
+///     fn enable(game: &mut Game, setup: &mut Setup<Self>) -> Self {
+///         // Initialize plugin state...
+///         Self {}
+///     }
+///
+///     fn disable(self, game: &mut Game) {
+///         // Clean up...
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn plugin(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
+    let cloned_item = item.clone();
+    let input = parse_macro_input!(cloned_item as Item);
+
+    let name = match input {
+        Item::Enum(itm_enum) => itm_enum.ident,
+        Item::Struct(itm_str) => itm_str.ident,
+        _ => panic!("Only structs or enums can be #[quill::plugin]!")
+    };
+    let res = quote! {
+        // `static mut` can be used without synchronization because the host
+        // guarantees it will not invoke plugin systems outside of the main thread.
+        static mut PLUGIN: Option<#name> = None;
+
+        // Exports to the host required for all plugins
+        #[no_mangle]
+        #[doc(hidden)]
+        #[cfg(target_arch = "wasm32")]
+        pub unsafe extern "C" fn quill_setup() {
+            let plugin: #name =
+                quill::Plugin::enable(&mut ::quill::Game::new(), &mut ::quill::Setup::new());
+            PLUGIN = Some(plugin);
+        }
+
+        #[no_mangle]
+        #[doc(hidden)]
+        #[cfg(not(target_arch = "wasm32"))]
+        pub unsafe extern "C" fn quill_setup(
+            context: *const (),
+            vtable_ptr: *const u8,
+            vtable_len: usize,
+        ) {
+            // Set up vtable and host context for quill_sys.
+            let vtable_bytes = ::std::slice::from_raw_parts(vtable_ptr, vtable_len);
+            let vtable: ::std::collections::HashMap<&str, usize> =
+                ::quill::bincode::deserialize(vtable_bytes).expect("invalid vtable");
+
+            ::quill::sys::init_host_context(context);
+            ::quill::sys::init_host_vtable(&vtable)
+                .expect("invalid vtable (check that the plugin and host are up to date)");
+
+            let plugin: #name =
+                quill::Plugin::enable(&mut ::quill::Game::new(), &mut ::quill::Setup::new());
+            PLUGIN = Some(plugin);
+        }
+
+        #[no_mangle]
+        #[doc(hidden)]
+        pub unsafe extern "C" fn quill_allocate(size: usize, align: usize) -> *mut u8 {
+            std::alloc::alloc(std::alloc::Layout::from_size_align_unchecked(size, align))
+        }
+
+        #[no_mangle]
+        #[doc(hidden)]
+        pub unsafe extern "C" fn quill_deallocate(ptr: *mut u8, size: usize, align: usize) {
+            std::alloc::dealloc(
+                ptr,
+                std::alloc::Layout::from_size_align_unchecked(size, align),
+            )
+        }
+
+        #[no_mangle]
+        #[doc(hidden)]
+        pub unsafe extern "C" fn quill_run_system(data: *mut u8) {
+            let system = &mut *data.cast::<Box<dyn FnMut(&mut #name, &mut ::quill::Game)>>();
+            let plugin = PLUGIN.as_mut().expect("quill_setup never called");
+            system(plugin, &mut ::quill::Game::new());
+        }
+
+        /// Never called by Quill, but this is needed
+        /// to avoid linker errors with WASI.
+        #[doc(hidden)]
+        fn main() {}
+    };
+    item.extend(TokenStream::from(res));
+    
+    item
+}

--- a/quill/api/src/lib.rs
+++ b/quill/api/src/lib.rs
@@ -32,6 +32,8 @@ pub extern crate bincode;
 #[doc(hidden)]
 pub extern crate quill_sys as sys;
 
+pub use plugin_macro::plugin;
+
 /// Implement this trait for your plugin's struct.
 pub trait Plugin: Sized {
     /// Invoked when the plugin is enabled.
@@ -54,99 +56,4 @@ pub trait Plugin: Sized {
     /// plugins at another time. Therefore, do not assume that
     /// the server is shutting down when this method is called.
     fn disable(self, game: &mut Game);
-}
-
-/// Invoke this macro in your plugin's main.rs.
-///
-///  Give it the name of your struct implementing `Plugin`.
-///
-/// # Example
-/// ```no_run
-/// // main.rs
-/// use quill::{Plugin, Setup, Game};
-///
-/// quill::plugin!(MyPlugin);
-///
-/// pub struct MyPlugin {
-///    // plugin state goes here
-/// }
-///
-/// impl Plugin for MyPlugin {
-///     fn enable(game: &mut Game, setup: &mut Setup<Self>) -> Self {
-///         // Initialize plugin state...
-///         Self {}
-///     }
-///
-///     fn disable(self, game: &mut Game) {
-///         // Clean up...
-///     }
-/// }
-/// ```
-#[macro_export]
-macro_rules! plugin {
-    ($plugin:ident) => {
-        // `static mut` can be used without synchronization because the host
-        // guarantees it will not invoke plugin systems outside of the main thread.
-        static mut PLUGIN: Option<$plugin> = None;
-
-        // Exports to the host required for all plugins
-        #[no_mangle]
-        #[doc(hidden)]
-        #[cfg(target_arch = "wasm32")]
-        pub unsafe extern "C" fn quill_setup() {
-            let plugin: $plugin =
-                quill::Plugin::enable(&mut $crate::Game::new(), &mut $crate::Setup::new());
-            PLUGIN = Some(plugin);
-        }
-
-        #[no_mangle]
-        #[doc(hidden)]
-        #[cfg(not(target_arch = "wasm32"))]
-        pub unsafe extern "C" fn quill_setup(
-            context: *const (),
-            vtable_ptr: *const u8,
-            vtable_len: usize,
-        ) {
-            // Set up vtable and host context for quill_sys.
-            let vtable_bytes = ::std::slice::from_raw_parts(vtable_ptr, vtable_len);
-            let vtable: ::std::collections::HashMap<&str, usize> =
-                $crate::bincode::deserialize(vtable_bytes).expect("invalid vtable");
-
-            $crate::sys::init_host_context(context);
-            $crate::sys::init_host_vtable(&vtable)
-                .expect("invalid vtable (check that the plugin and host are up to date)");
-
-            let plugin: $plugin =
-                quill::Plugin::enable(&mut $crate::Game::new(), &mut $crate::Setup::new());
-            PLUGIN = Some(plugin);
-        }
-
-        #[no_mangle]
-        #[doc(hidden)]
-        pub unsafe extern "C" fn quill_allocate(size: usize, align: usize) -> *mut u8 {
-            std::alloc::alloc(std::alloc::Layout::from_size_align_unchecked(size, align))
-        }
-
-        #[no_mangle]
-        #[doc(hidden)]
-        pub unsafe extern "C" fn quill_deallocate(ptr: *mut u8, size: usize, align: usize) {
-            std::alloc::dealloc(
-                ptr,
-                std::alloc::Layout::from_size_align_unchecked(size, align),
-            )
-        }
-
-        #[no_mangle]
-        #[doc(hidden)]
-        pub unsafe extern "C" fn quill_run_system(data: *mut u8) {
-            let system = &mut *data.cast::<Box<dyn FnMut(&mut $plugin, &mut $crate::Game)>>();
-            let plugin = PLUGIN.as_mut().expect("quill_setup never called");
-            system(plugin, &mut $crate::Game::new());
-        }
-
-        /// Never called by Quill, but this is needed
-        /// to avoid linker errors with WASI.
-        #[doc(hidden)]
-        fn main() {}
-    };
 }

--- a/quill/example-plugins/block-access/src/lib.rs
+++ b/quill/example-plugins/block-access/src/lib.rs
@@ -2,8 +2,7 @@
 
 use quill::{entities::Player, BlockState, Game, Plugin, Position};
 
-quill::plugin!(BlockAccess);
-
+#[quill::plugin]
 pub struct BlockAccess;
 
 impl Plugin for BlockAccess {

--- a/quill/example-plugins/block-place/src/lib.rs
+++ b/quill/example-plugins/block-place/src/lib.rs
@@ -2,8 +2,7 @@
 
 use quill::{events::BlockPlacementEvent, Game, Plugin};
 
-quill::plugin!(BlockPlace);
-
+#[quill::plugin]
 pub struct BlockPlace;
 
 impl Plugin for BlockPlace {

--- a/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
+++ b/quill/example-plugins/observe-creativemode-flight-event/src/lib.rs
@@ -9,8 +9,7 @@ use quill::{
     Game, Plugin, Setup,
 };
 
-quill::plugin!(FlightPlugin);
-
+#[quill::plugin]
 struct FlightPlugin {}
 
 impl Plugin for FlightPlugin {

--- a/quill/example-plugins/particle-example/src/lib.rs
+++ b/quill/example-plugins/particle-example/src/lib.rs
@@ -1,7 +1,6 @@
 use quill::{Game, Particle, ParticleKind, Plugin, Position};
 
-quill::plugin!(ParticleExample);
-
+#[quill::plugin]
 struct ParticleExample {}
 
 impl Plugin for ParticleExample {

--- a/quill/example-plugins/plugin-message/src/lib.rs
+++ b/quill/example-plugins/plugin-message/src/lib.rs
@@ -2,7 +2,6 @@
 //! send a player to a server named lobby.
 use quill::{entities::Player, BlockPosition, Game, Plugin, Position};
 
-
 #[quill::plugin]
 pub struct PluginMessage;
 

--- a/quill/example-plugins/plugin-message/src/lib.rs
+++ b/quill/example-plugins/plugin-message/src/lib.rs
@@ -2,8 +2,8 @@
 //! send a player to a server named lobby.
 use quill::{entities::Player, BlockPosition, Game, Plugin, Position};
 
-quill::plugin!(PluginMessage);
 
+#[quill::plugin]
 pub struct PluginMessage;
 
 impl Plugin for PluginMessage {

--- a/quill/example-plugins/query-entities/src/lib.rs
+++ b/quill/example-plugins/query-entities/src/lib.rs
@@ -4,8 +4,7 @@
 use quill::{entities::PiglinBrute, EntityInit, Game, Plugin, Position};
 use rand::Rng;
 
-quill::plugin!(QueryEntities);
-
+#[quill::plugin]
 struct QueryEntities {
     tick_counter: u64,
 }

--- a/quill/example-plugins/simple/src/lib.rs
+++ b/quill/example-plugins/simple/src/lib.rs
@@ -5,8 +5,7 @@ use quill::{
 };
 use rand::Rng;
 
-quill::plugin!(SimplePlugin);
-
+#[quill::plugin]
 struct SimplePlugin {
     tick_counter: u64,
 }

--- a/quill/example-plugins/titles/src/lib.rs
+++ b/quill/example-plugins/titles/src/lib.rs
@@ -1,7 +1,6 @@
 use quill::{entities::Player, Game, Plugin, Text, TextComponent, TextComponentBuilder, Title};
 
-quill::plugin!(TitleExample);
-
+#[quill::plugin]
 struct TitleExample {
     tick_count: u32,
     title_active: bool,


### PR DESCRIPTION
# Turned `quill::plugin` into a proc macro

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Made it so that a plugin is initialized using
```rust
#[plugin::quill]
struct MyPlugin;
```
instead of
```rust
struct MyPlugin;

quill::plugin!(MyPlugin);
```

_Note: Although it works, someone that knows how to do proc macros should maybe check the code for improvements that could be done._

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.