### PR TITLE
Added data field to the Particle Struct and particles system

### DIFF
--- a/feather/server/src/client.rs
+++ b/feather/server/src/client.rs
@@ -557,7 +557,7 @@ impl Client {
             offset_x: particle.offset_x,
             offset_y: particle.offset_y,
             offset_z: particle.offset_z,
-            particle_data: 0.0,
+            particle_data: particle.data,
             particle_count: particle.count,
         })
     }

--- a/libcraft/particles/src/particle.rs
+++ b/libcraft/particles/src/particle.rs
@@ -11,6 +11,7 @@ pub struct Particle {
     pub offset_y: f32,
     pub offset_z: f32,
     pub count: i32,
+    pub data: f32,
 }
 
 /// This is an enum over the kinds of particles

--- a/quill/api/src/game.rs
+++ b/quill/api/src/game.rs
@@ -128,8 +128,7 @@ impl Game {
     ///     offset_y: 0.0,
     ///     offset_z: 0.0,
     ///     count: 1,
-    ///     pub particle_data: f32,
-    ///     pub particle_count: i32,
+    ///     data: 0.0,
     /// };
     ///
     /// game.spawn_particle(position, particle);

--- a/quill/api/src/game.rs
+++ b/quill/api/src/game.rs
@@ -128,6 +128,8 @@ impl Game {
     ///     offset_y: 0.0,
     ///     offset_z: 0.0,
     ///     count: 1,
+    ///     pub particle_data: f32,
+    ///     pub particle_count: i32,
     /// };
     ///
     /// game.spawn_particle(position, particle);

--- a/quill/example-plugins/particle-example/src/lib.rs
+++ b/quill/example-plugins/particle-example/src/lib.rs
@@ -28,6 +28,7 @@ fn particle_system(_plugin: &mut ParticleExample, game: &mut Game) {
         offset_y: 0.0,
         offset_z: 0.0,
         count: 1,
+        data: 0.0,
     };
 
     game.spawn_particle(position, particle);
@@ -45,6 +46,7 @@ fn particle_system(_plugin: &mut ParticleExample, game: &mut Game) {
         offset_y: 0.0,
         offset_z: 0.0,
         count: 1,
+        data: 0.0,
     };
 
     // Initialise an empty ecs-entity builder


### PR DESCRIPTION
# Added data field to the Particle Struct and particles system

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

- Added field `data: f32` to struct struct Particle.
- Added that field in `send_particle()` 
- Added that field to particle-examples

## Related issues

_Leave empty if none_

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.