### PR TITLE
bump target-lexicon version to match main crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
  "log",
  "regalloc",
  "smallvec",
- "target-lexicon 0.12.2",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.12.2",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -2095,7 +2095,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tar",
- "target-lexicon 0.11.2",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -2841,12 +2841,6 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
-
-[[package]]
-name = "target-lexicon"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
@@ -3261,7 +3255,7 @@ dependencies = [
  "js-sys",
  "loupe",
  "more-asserts",
- "target-lexicon 0.12.2",
+ "target-lexicon",
  "thiserror",
  "wasm-bindgen",
  "wasmer-compiler",
@@ -3288,7 +3282,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "smallvec",
- "target-lexicon 0.12.2",
+ "target-lexicon",
  "thiserror",
  "wasmer-types",
  "wasmer-vm",
@@ -3309,7 +3303,7 @@ dependencies = [
  "more-asserts",
  "rayon",
  "smallvec",
- "target-lexicon 0.12.2",
+ "target-lexicon",
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
@@ -3335,7 +3329,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "semver 1.0.4",
  "smallvec",
- "target-lexicon 0.12.2",
+ "target-lexicon",
  "wasmer-compiler",
  "wasmer-types",
  "wasmer-vm",
@@ -3368,7 +3362,7 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "serde_bytes",
- "target-lexicon 0.12.2",
+ "target-lexicon",
  "thiserror",
  "wasmer-compiler",
  "wasmer-types",

--- a/quill/plugin-format/Cargo.toml
+++ b/quill/plugin-format/Cargo.toml
@@ -11,4 +11,4 @@ flate2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = "1"
-target-lexicon = "0.11"
+target-lexicon = "0.12"


### PR DESCRIPTION
# TITLE - Replace

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

The main crate uses 0.12 already, and this removes the duplicated implementation of `target-lexicon`. No source changes seem to be needed

## Related issues

_Leave empty if none_

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.