### PR TITLE
Update cargo_metadata to 0.14 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,13 +355,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.12.3"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
 dependencies = [
+ "camino",
  "cargo-platform",
- "semver 0.11.0",
- "semver-parser 0.10.2",
+ "semver 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -2482,7 +2491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
- "serde",
 ]
 
 [[package]]
@@ -2490,6 +2498,9 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/quill/cargo-quill/Cargo.toml
+++ b/quill/cargo-quill/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 quill-plugin-format = { path = "../plugin-format" }
-cargo_metadata = "0.12"
+cargo_metadata = "0.14.1"
 anyhow = "1"
 argh = "0.1"
 heck = "0.3"

--- a/quill/cargo-quill/src/main.rs
+++ b/quill/cargo-quill/src/main.rs
@@ -68,7 +68,7 @@ impl Build {
             target_dir.push("debug");
         }
 
-        target_dir
+        target_dir.into()
     }
 
     pub fn module_path(&self, cargo_meta: &Metadata, plugin_meta: &PluginMetadata) -> PathBuf {


### PR DESCRIPTION
... to match rustc_version 0.4.0, removing an extra copy of semver in the dependency tree

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold
## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.