### PR TITLE
Use cargo deny in CI

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,205 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    #"MIT",
+    #"Apache-2.0",
+    #"Apache-2.0 WITH LLVM-exception",
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = [""]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = [""]

--- a/deny.toml
+++ b/deny.toml
@@ -160,7 +160,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
+multiple-versions = "deny"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates
@@ -185,7 +185,30 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+    { name = "time", version = "0.2.27" }, # used by wasmer. we cannot downgrade
+    { name = "time-macros", version = "0.1.1" },
+    { name = "spin", version = "0.5.2" }, # used by ring. we cannot downgrade
+    { name = "semver", version = "0.9.0" }, # used by wasmer (through time, stdweb and rustc_version 0.2.3).  We can downgrade to match
+    { name = "rustc_version", version = "0.2.3" }, # vek and stdweb use this version. We can downgrade derive_more to match
+    { name = "paste", version = "0.1.18" }, # simdeez uses an alpha version of `paste`. We could downgrade to match
+    { name = "gimli", version = "0.25.0" }, # wasmer includes multiple versions of gimli
+    { name = "cfg-if", version = "0.1.10" }, # used by generational-arena and simdeez. 
+    { name = "autocfg", version = "0.1.7" }, # used by rsa (through num-bigint-dig)
+    { name = "arrayvec", version = "0.5.2" }, # used by nom. we can upgrade to nom 0.7
+    { name = "approx", version = "0.3.2" }, # we can upgrade to 0.4 in feather-worldgen
+    { name = "ahash", version = "0.4.7" }, # we can upgrade to 0.7 in feather-{base, datapacks}
+    { name = "wasi", version = "0.9.0"},  # used by rand 0.7.3. we can upgrade to rand 0.8
+    { name = "target-lexicon", version = "0.12.2" }, # we can upgrade to 0.12
+    { name = "semver", version = "0.11.0" }, # used by cargo_metadata 0.12. we can upgrade to cargo_metadata 0.14
+    { name = "semver-parser", version = "0.10.2" },
+    { name = "rand", version = "0.7.3" }, # we can upgrade to rand 0.8
+    { name = "rand_core", version = "0.5.1" },
+    { name = "rand_chacha", version = "0.2.2" },
+    { name = "rand_hc", version = "0.2.0" },
+    { name = "getrandom", version = "0.1.16" },
+    { name = "heck", version = "0.4.0" }, # used by clap. we can reuse argh, which targets heck 0.3
+    { name = "hashbrown", version = "0.9.1" }, # used by hecs 0.3. we can upgrade to hecs 0.7
+    { name = "bytes", version = "0.5.6" }, # we can upgrade to bytes 1.0
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/deny.toml
+++ b/deny.toml
@@ -213,8 +213,4 @@ allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = [""]
-# 1 or more gitlab.com organizations to allow git sources for
-gitlab = [""]
-# 1 or more bitbucket.org organizations to allow git sources for
-bitbucket = [""]
+github = ["jackmott", "PistonDevelopers", "feather-rs"]

--- a/deny.toml
+++ b/deny.toml
@@ -70,9 +70,16 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    #"MIT",
-    #"Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MPL-2.0",
+    "ISC",
+    "Zlib",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "CC0-1.0",
+    "LicenseRef-ring",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -105,6 +112,14 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/feather/base/Cargo.toml
+++ b/feather/base/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-base"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/blocks/Cargo.toml
+++ b/feather/blocks/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-blocks"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/blocks/generator/Cargo.toml
+++ b/feather/blocks/generator/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-blocks-generator"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/feather/common/Cargo.toml
+++ b/feather/common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-common"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/datapacks/Cargo.toml
+++ b/feather/datapacks/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-datapacks"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/ecs/Cargo.toml
+++ b/feather/ecs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-ecs"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/plugin-host/Cargo.toml
+++ b/feather/plugin-host/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-plugin-host"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/plugin-host/macros/Cargo.toml
+++ b/feather/plugin-host/macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-plugin-host-macros"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/feather/protocol/Cargo.toml
+++ b/feather/protocol/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-protocol"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/server/Cargo.toml
+++ b/feather/server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-server"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 default-run = "feather-server"

--- a/feather/utils/Cargo.toml
+++ b/feather/utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-utils"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/feather/worldgen/Cargo.toml
+++ b/feather/worldgen/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "feather-worldgen"
 version = "0.6.0"
+license = "Apache-2.0"
 authors = [ "caelunshun <caelunshun@gmail.com>" ]
 edition = "2018"
 

--- a/libcraft/blocks/Cargo.toml
+++ b/libcraft/blocks/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-blocks"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Caelum van Ispelen <caelum12321@gmail.com>"]
 edition = "2018"
 

--- a/libcraft/core/Cargo.toml
+++ b/libcraft/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-core"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/libcraft/generators/Cargo.toml
+++ b/libcraft/generators/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-generators"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Kalle Kankaanpää"]
 edition = "2018"
 

--- a/libcraft/inventory/Cargo.toml
+++ b/libcraft/inventory/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-inventory"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Tracreed <davidalasow@gmail.com>"]
 edition = "2018"
 

--- a/libcraft/items/Cargo.toml
+++ b/libcraft/items/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-items"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Kalle Kankaanpää", "Pau Machetti <paumachetti@gmail.com>"]
 edition = "2018"
 

--- a/libcraft/macros/Cargo.toml
+++ b/libcraft/macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-macros"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Kalle Kankaanpää"]
 edition = "2018"
 

--- a/libcraft/particles/Cargo.toml
+++ b/libcraft/particles/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-particles"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Gijs de Jong <berichtaangijs@gmail.com>"]
 edition = "2018"
 

--- a/libcraft/text/Cargo.toml
+++ b/libcraft/text/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libcraft-text"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Gijs de Jong <berichtaangijs@gmail.com>", "caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "proxy"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/quill/api/Cargo.toml
+++ b/quill/api/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "quill"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/api/plugin-macro/Cargo.toml
+++ b/quill/api/plugin-macro/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "plugin-macro"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [lib]

--- a/quill/cargo-quill/Cargo.toml
+++ b/quill/cargo-quill/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cargo-quill"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/common/Cargo.toml
+++ b/quill/common/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "quill-common"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/block-access/Cargo.toml
+++ b/quill/example-plugins/block-access/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "block-access"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/block-place/Cargo.toml
+++ b/quill/example-plugins/block-place/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "block-place"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Amber Kowalski <amberkowalski03@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/observe-creativemode-flight-event/Cargo.toml
+++ b/quill/example-plugins/observe-creativemode-flight-event/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "observe-creativemode-flight-event"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Miro Andrin <miro.sveits@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/particle-example/Cargo.toml
+++ b/quill/example-plugins/particle-example/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "particle-example"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Gijs de Jong <berichtaangijs@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/plugin-message/Cargo.toml
+++ b/quill/example-plugins/plugin-message/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "plugin-message"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Derek Lee <derek.scott.lee13@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/query-entities/Cargo.toml
+++ b/quill/example-plugins/query-entities/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "query-entities"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Caelum van Ispelen <caelum12321@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/simple/Cargo.toml
+++ b/quill/example-plugins/simple/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "simple-plugin"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/example-plugins/titles/Cargo.toml
+++ b/quill/example-plugins/titles/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "titles"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["Gijs de Jong <berichtaangijs@gmail.com>"]
 edition = "2018"
 

--- a/quill/plugin-format/Cargo.toml
+++ b/quill/plugin-format/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "quill-plugin-format"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/sys-macros/Cargo.toml
+++ b/quill/sys-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "quill-sys-macros"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 

--- a/quill/sys/Cargo.toml
+++ b/quill/sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "quill-sys"
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["caelunshun <caelunshun@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

As mentioned in https://github.com/feather-rs/feather/issues/531#issuecomment-1032325505, I've setup the repo to use `cargo deny`. It is now correctly checking everything, and allowing for a set of exceptions in `deny.toml`.

All that's left is adding a workflow for running the tool.

## Related issues

_Leave empty if none_

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.