### PR TITLE
Remove the bug notice in quill/README.md

### DIFF
--- a/quill/README.md
+++ b/quill/README.md
@@ -7,8 +7,3 @@ Plugins written for [Feather](https://github.com/feather-rs/feather) servers use
 
 ## For Feather developers
 See [`docs`](./docs) for information on Quill internals.
-
-## __**Important Notice For Plugin Developers**__
-There is currently a miscompilation issue with the latest versions of rustc! 
-
-__**1.51.0 IS CONFIRMED STABLE, PLEASE USE IT IF YOU ARE COMPILING PLUGINS**__


### PR DESCRIPTION
# Remove the bug notice in quill/README.md

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

It was fixed in #524

## Related issues

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.