### PR TITLE
Allow optionally building without plugin-host

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --features plugin-cranelift
 
   build:
     name: Cargo build & test
@@ -102,6 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        features: ["", "--features plugin-cranelift"]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -136,4 +138,4 @@ jobs:
         with:
           use-cross: ${{ matrix.use-cross }}
           command: build
-          args: --target=${{ matrix.target }}
+          args: --target=${{ matrix.target }} ${{ matrix.features }}

--- a/feather/server/Cargo.toml
+++ b/feather/server/Cargo.toml
@@ -33,7 +33,7 @@ num-bigint = "0.4"
 num-traits = "0.2"
 once_cell = "1"
 parking_lot = "0.11"
-plugin-host = { path = "../plugin-host", package = "feather-plugin-host" }
+plugin-host = { path = "../plugin-host", package = "feather-plugin-host", optional = true }
 protocol = { path = "../protocol", package = "feather-protocol" }
 quill-common = { path = "../../quill/common" }
 
@@ -58,15 +58,15 @@ libcraft-items = { path = "../../libcraft/items" }
 worldgen = { path = "../worldgen", package = "feather-worldgen" }
 
 [features]
-default = [ "plugin-cranelift" ]
+default = []
 
 # Use zlib-ng for faster compression. Requires CMake.
 zlib-ng = [ "flate2/zlib-ng-compat" ]
-
+plugins = ["plugin-host"]
 # Use Cranelift to JIT-compile plugins. Pure Rust
 # but produces slower code than LLVM.
-plugin-cranelift = [ "plugin-host/cranelift" ]
+plugin-cranelift = [ "plugins", "plugin-host/cranelift" ]
 # Use LLVM to JIT-compile plugins. Produces
 # very fast code, but requires LLVM to be installed
 # on the build system. May impact startup times.
-plugin-llvm = [ "plugin-host/llvm" ]
+plugin-llvm = [ "plugins", "plugin-host/llvm" ]

--- a/feather/server/src/main.rs
+++ b/feather/server/src/main.rs
@@ -5,11 +5,13 @@ use base::anvil::level::SuperflatGeneratorOptions;
 use common::{Game, TickLoop, World};
 use ecs::SystemExecutor;
 use feather_server::{config::Config, Server};
+#[cfg(feature = "plugins")]
 use plugin_host::PluginManager;
 use worldgen::{ComposableGenerator, SuperflatWorldGenerator, VoidWorldGenerator, WorldGenerator};
 
 mod logging;
 
+#[cfg(feature = "plugins")]
 const PLUGINS_DIRECTORY: &str = "plugins";
 const CONFIG_PATH: &str = "config.toml";
 
@@ -40,6 +42,7 @@ fn init_game(server: Server, config: &Config) -> anyhow::Result<Game> {
     let mut game = Game::new();
     init_systems(&mut game, server);
     init_world_source(&mut game, config);
+    #[cfg(feature = "plugins")]
     init_plugin_manager(&mut game)?;
     Ok(game)
 }
@@ -75,7 +78,7 @@ fn init_world_source(game: &mut Game, config: &Config) {
     };
     game.world = World::with_gen_and_path(generator, config.world.name.clone());
 }
-
+#[cfg(feature = "plugins")]
 fn init_plugin_manager(game: &mut Game) -> anyhow::Result<()> {
     let mut plugin_manager = PluginManager::new();
     plugin_manager.load_dir(game, PLUGINS_DIRECTORY)?;


### PR DESCRIPTION
## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

This was fantastic! The implementation was already very cleanly separated so it wasn't any trouble to turn `plugin-host` off all together. This saves a bunch of compilation time for me 😁

I'm not very well versed in github actions, but I've made an attempt at extending the CI to test both with and without the plugins enabled. Let's see if it works...

## Related issues

_Leave empty if none_

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.