### PR TITLE
Clippy 1.59

### DIFF
--- a/feather/common/src/world.rs
+++ b/feather/common/src/world.rs
@@ -199,7 +199,7 @@ impl ChunkMap {
     /// Retrieves a handle to the chunk at the given
     /// position, or `None` if it is not loaded.
     pub fn chunk_at_mut(&self, pos: ChunkPosition) -> Option<RwLockWriteGuard<Chunk>> {
-        self.0.get(&pos).map(|lock| lock.write()).flatten()
+        self.0.get(&pos).and_then(|lock| lock.write())
     }
 
     /// Returns an `Arc<RwLock<Chunk>>` at the given position.
@@ -212,8 +212,7 @@ impl ChunkMap {
 
         let (x, y, z) = chunk_relative_pos(pos.into());
         self.chunk_at(pos.chunk())
-            .map(|chunk| chunk.block_at(x, y, z))
-            .flatten()
+            .and_then(|chunk| chunk.block_at(x, y, z))
     }
 
     pub fn set_block_at(&self, pos: ValidBlockPosition, block: BlockId) -> bool {

--- a/feather/protocol/src/io.rs
+++ b/feather/protocol/src/io.rs
@@ -565,7 +565,7 @@ impl Readable for Slot {
             Ok(Filled(
                 ItemStackBuilder::with_item(item)
                     .count(count)
-                    .apply_damage(tags.map(|t| t.damage).flatten())
+                    .apply_damage(tags.and_then(|t| t.damage))
                     .into(),
             ))
         } else {

--- a/feather/server/src/initial_handler/proxy/bungeecord.rs
+++ b/feather/server/src/initial_handler/proxy/bungeecord.rs
@@ -88,8 +88,9 @@ mod tests {
     fn extract_bungeecord_data_too_long() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "192.168.1.87\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2\x00a\x00b"
-                .to_string(),
+            server_address:
+                "192.168.1.87\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2\x00a\x00b"
+                    .to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
         };

--- a/feather/server/src/initial_handler/proxy/bungeecord.rs
+++ b/feather/server/src/initial_handler/proxy/bungeecord.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::octal_escapes)]
 use std::str::FromStr;
 
 use anyhow::bail;
@@ -50,7 +51,7 @@ mod tests {
     fn extract_bungeecord_data_normal() {
         let handshake = Handshake {
            protocol_version: PROTOCOL_VERSION,
-           server_address: "192.168.1.87\0192.168.1.67\0905c7e4fb96b45139645d123225575e2\0[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
+           server_address: "192.168.1.87\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2\x00[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
            server_port: 25565,
            next_state: HandshakeState::Login,
         };
@@ -74,7 +75,7 @@ mod tests {
     fn extract_bungeecord_data_too_short() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "192.168.1.87\0192.168.1.67\0905c7e4fb96b45139645d123225575e2"
+            server_address: "192.168.1.87\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2"
                 .to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
@@ -87,7 +88,7 @@ mod tests {
     fn extract_bungeecord_data_too_long() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "192.168.1.87\0192.168.1.67\0905c7e4fb96b45139645d123225575e2\0a\0b"
+            server_address: "192.168.1.87\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2\x00a\x00b"
                 .to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
@@ -100,7 +101,7 @@ mod tests {
     fn extract_bungeecord_data_localhost_host_ip() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "localhost\0192.168.1.67\0905c7e4fb96b45139645d123225575e2\0[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
+            server_address: "localhost\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2\x00[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
         };
@@ -124,7 +125,7 @@ mod tests {
     fn extract_bungeecord_data_localhost_client_ip() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "192.168.1.87\0localhost\0905c7e4fb96b45139645d123225575e2\0[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
+            server_address: "192.168.1.87\x00localhost\x00905c7e4fb96b45139645d123225575e2\x00[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
         };
@@ -148,7 +149,7 @@ mod tests {
     fn extract_bungeecord_data_invalid_uuid() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "192.168.1.87\0192.168.1.67\005c7e4fb9675e2\0[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
+            server_address: "192.168.1.87\x00192.168.1.67\x0005c7e4fb9675e2\x00[{\"name\":\"textures\",\"value\":\"textures_value\",\"signature\":\"textures_signature\"}]".to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
         };
@@ -160,7 +161,7 @@ mod tests {
     fn extract_bungeecord_data_invalid_properties() {
         let handshake = Handshake {
             protocol_version: PROTOCOL_VERSION,
-            server_address: "192.168.1.87\0192.168.1.67\0905c7e4fb96b45139645d123225575e2\0[{\"name\":\"textures\",\"value\":\"textures_value\",\"sinature\":\"textures_signature\"}]".to_string(),
+            server_address: "192.168.1.87\x00192.168.1.67\x00905c7e4fb96b45139645d123225575e2\x00[{\"name\":\"textures\",\"value\":\"textures_value\",\"sinature\":\"textures_signature\"}]".to_string(),
             server_port: 25565,
             next_state: HandshakeState::Login,
         };

--- a/libcraft/blocks/src/data.rs
+++ b/libcraft/blocks/src/data.rs
@@ -121,7 +121,7 @@ impl BlockReportEntry {
         <T as FromStr>::Err: std::fmt::Debug,
     {
         if let Some(vec) = self.properties.get(name) {
-            vec.iter().map(|s| T::from_str(s).ok()).flatten().collect()
+            vec.iter().filter_map(|s| T::from_str(s).ok()).collect()
         } else {
             Vec::new()
         }

--- a/libcraft/generators/src/common.rs
+++ b/libcraft/generators/src/common.rs
@@ -32,7 +32,6 @@ pub fn compress_and_write<T: Serialize>(data: Vec<T>, path: &str) -> Result<()> 
 pub fn state_name_to_block_kind(name: &str) -> Result<BlockKind> {
     name.split(':')
         .last()
-        .map(BlockKind::from_name)
-        .flatten()
+        .and_then(BlockKind::from_name)
         .ok_or_else(|| anyhow!("Could not convert state name to BlockKind"))
 }

--- a/libcraft/items/src/inventory_slot.rs
+++ b/libcraft/items/src/inventory_slot.rs
@@ -49,11 +49,13 @@ impl InventorySlot {
     }
 
     /// Takes all items and makes self empty.
+    #[must_use]
     pub fn take_all(&mut self) -> Self {
         mem::take(self)
     }
 
     /// Takes half (rounded down) of the items in self.
+    #[must_use]
     pub fn take_half(&mut self) -> Self {
         let half = (self.count() + 1) / 2;
         self.try_take(half)
@@ -63,6 +65,7 @@ impl InventorySlot {
     /// and put it into the output. If amount is bigger
     /// then what self can provide then this is the same
     /// as calling take.
+    #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn try_take(&mut self, amount: u32) -> Self {
         if amount == 0 {

--- a/libcraft/items/src/item_stack.rs
+++ b/libcraft/items/src/item_stack.rs
@@ -455,12 +455,14 @@ impl ItemStackBuilder {
     }
 
     /// Set the item `title`.
+    #[must_use]
     pub fn title(mut self, title: impl AsRef<str>) -> Self {
         self.get_or_init_meta().title = title.as_ref().to_owned();
         self
     }
 
     /// Set the item `lore`.
+    #[must_use]
     pub fn lore(mut self, lore: impl AsRef<str>) -> Self {
         self.get_or_init_meta().lore = lore.as_ref().to_owned();
         self

--- a/quill/cargo-quill/src/main.rs
+++ b/quill/cargo-quill/src/main.rs
@@ -73,7 +73,7 @@ impl Build {
 
     pub fn module_path(&self, cargo_meta: &Metadata, plugin_meta: &PluginMetadata) -> PathBuf {
         let target_dir = self.target_dir(cargo_meta);
-        let module_filename = plugin_meta.identifier.replace("-", "_");
+        let module_filename = plugin_meta.identifier.replace('-', "_");
 
         let module_extension = self.module_extension();
         let lib_prefix = if self.native && cfg!(unix) { "lib" } else { "" };


### PR DESCRIPTION
# Fix new lints of clippy 1.59

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description
Basically what the title says.

## Related issues

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.