### PR TITLE
Apply 1.60 clippy lints and apply variable name

### DIFF
--- a/feather/base/src/anvil/player.rs
+++ b/feather/base/src/anvil/player.rs
@@ -80,9 +80,7 @@ impl InventorySlot {
             -106
         } else if SLOT_ARMOR_MIN <= index && index <= SLOT_ARMOR_MAX {
             ((SLOT_ARMOR_MAX - index) + 100) as i8
-        } else if SLOT_INVENTORY_OFFSET <= index
-            && index < SLOT_INVENTORY_OFFSET + INVENTORY_SIZE
-        {
+        } else if SLOT_INVENTORY_OFFSET <= index && index < SLOT_INVENTORY_OFFSET + INVENTORY_SIZE {
             index as i8
         } else {
             return None;

--- a/feather/base/src/anvil/player.rs
+++ b/feather/base/src/anvil/player.rs
@@ -71,18 +71,19 @@ pub struct InventorySlot {
 
 impl InventorySlot {
     /// Converts an [`ItemStack`] and network protocol index into an [`InventorySlot`].
-    pub fn from_network_index(network: usize, stack: &ItemStack) -> Option<Self> {
-        let slot = if SLOT_HOTBAR_OFFSET <= network && network < SLOT_HOTBAR_OFFSET + HOTBAR_SIZE {
+    #[allow(clippy::manual_range_contains)]
+    pub fn from_network_index(index: usize, stack: &ItemStack) -> Option<Self> {
+        let slot = if SLOT_HOTBAR_OFFSET <= index && index < SLOT_HOTBAR_OFFSET + HOTBAR_SIZE {
             // Hotbar
-            (network - SLOT_HOTBAR_OFFSET) as i8
-        } else if network == SLOT_OFFHAND {
+            (index - SLOT_HOTBAR_OFFSET) as i8
+        } else if index == SLOT_OFFHAND {
             -106
-        } else if SLOT_ARMOR_MIN <= network && network <= SLOT_ARMOR_MAX {
-            ((SLOT_ARMOR_MAX - network) + 100) as i8
-        } else if SLOT_INVENTORY_OFFSET <= network
-            && network < SLOT_INVENTORY_OFFSET + INVENTORY_SIZE
+        } else if SLOT_ARMOR_MIN <= index && index <= SLOT_ARMOR_MAX {
+            ((SLOT_ARMOR_MAX - index) + 100) as i8
+        } else if SLOT_INVENTORY_OFFSET <= index
+            && index < SLOT_INVENTORY_OFFSET + INVENTORY_SIZE
         {
-            network as i8
+            index as i8
         } else {
             return None;
         };

--- a/feather/worldgen/src/lib.rs
+++ b/feather/worldgen/src/lib.rs
@@ -340,9 +340,9 @@ impl NearbyBiomes {
         let chunk_x = (x / 16) as usize;
         let chunk_z = (z / 16) as usize;
 
-        let mut local_x = (ox % 16).abs() as usize;
-        let local_y = (oy % 16).abs() as usize;
-        let mut local_z = (oz % 16).abs() as usize;
+        let mut local_x = (ox % 16).unsigned_abs();
+        let local_y = (oy % 16).unsigned_abs();
+        let mut local_z = (oz % 16).unsigned_abs();
 
         if ox < 0 {
             local_x = 16 - local_x;

--- a/libcraft/items/src/item_stack.rs
+++ b/libcraft/items/src/item_stack.rs
@@ -366,7 +366,7 @@ pub enum ItemStackError {
 
 impl Display for ItemStackError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Fixed all new lints that came with clippy 1.60 (and also some of nightly clippy).

## Checklist

- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [x] Removed unnecessary commented out code
- [x] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.