### PR TITLE
fixing typo in docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ The component can then be accessed both from Feather and from plugins.
 In Feather, events are components. An entity with the `PlayerJoinEvent` component just joined
 the game, for example.
 
-The event sytsem serves as a mechanism to communicate between different crates and modules.
+The event system serves as a mechanism to communicate between different crates and modules.
 For example, triggering a `BlockChangeEvent` _anywhere_ causes `feather-server` to send block
 update packets to players.
 


### PR DESCRIPTION
# Fixing Typo

## Status

- [x] Ready 
- [ ] Development
- [ ] Hold

## Description

Fixed typo in docs/architecture.md: sytsem -> system

## Related issues

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.