### PR TITLE
capture backtrace if tick too long

### DIFF
--- a/feather/common/src/tick_loop.rs
+++ b/feather/common/src/tick_loop.rs
@@ -1,4 +1,6 @@
 use std::time::Instant;
+use std::backtrace::Backtrace;
+use std::time::Duration;
 
 use base::TICK_DURATION;
 
@@ -22,6 +24,7 @@ impl TickLoop {
     pub fn run(mut self) {
         loop {
             let start = Instant::now();
+           
             let should_exit = (self.function)();
             if should_exit {
                 return;
@@ -29,7 +32,8 @@ impl TickLoop {
 
             let elapsed = start.elapsed();
             if elapsed > TICK_DURATION {
-                log::warn!("Tick took too long ({:?})", elapsed);
+                let bt = Backtrace::force_capture();
+                log::warn!("Tick took too long ({:?}), backtrace: {:?}", elapsed, bt);
             } else {
                 std::thread::sleep(TICK_DURATION - elapsed);
             }


### PR DESCRIPTION
# TITLE - Replace

## Status

- [ ] Ready 
- [x] Development
- [ ] Hold

## Description

Not a fix, but I think useful to log a backtrace if we hit long ticks

## Related issues

_Leave empty if none_

## Checklist

- [ ] Ran `cargo fmt`, `cargo clippy --all-targets`, `cargo build --release` and `cargo test` and fixed any generated errors!
- [ ] Removed unnecessary commented out code
- [ ] Used specific traces (if you trace actions please specify the cause i.e. the player)

Note: if you locally don't get any errors, but GitHub Actions fails (especially at `clippy`) you might want to check your rust toolchain version. You can then feel free to fix these warnings/errors in your PR.