### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/feather/base/src/anvil/block_entity.rs
+++ b/feather/base/src/anvil/block_entity.rs
@@ -6,7 +6,7 @@ use super::player::InventorySlot;
 /// A block entity loaded or saved to the Anvil format.
 /// Should be serialized using NBT.
 ///
-/// <https://minecraft.gamepedia.com/Chunk_format#Block_entity_format>
+/// <https://minecraft.wiki/w/Chunk_format#Block_entity_format>
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockEntityData {
     #[serde(flatten)]

--- a/feather/datapacks/src/id.rs
+++ b/feather/datapacks/src/id.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 /// A namespaced identifier, also known as a "resource location"
-/// in Forge. See <https://minecraft.gamepedia.com/Namespaced_ID>.
+/// in Forge. See <https://minecraft.wiki/w/Namespaced_ID>.
 ///
 /// Namespaced IDs can be parsed using the `FromStr` implementation,
 /// and they can be formatted using the `Display` impl or by calling `to_string()`.

--- a/feather/old/core/loot/model/src/lib.rs
+++ b/feather/old/core/loot/model/src/lib.rs
@@ -22,7 +22,7 @@ impl Default for LootTableSet {
     }
 }
 
-/// See https://minecraft.gamepedia.com/Loot_table
+/// See https://minecraft.wiki/w/Loot_table
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LootTable {
     #[serde(rename = "type")]

--- a/feather/old/definitions/data/tool.ron
+++ b/feather/old/definitions/data/tool.ron
@@ -54,7 +54,7 @@ Multiple([
         on: "item",
         name: "durability",
         type: u32,
-        // https://minecraft.gamepedia.com/Item_durability
+        // https://minecraft.wiki/w/Item_durability
         mapping: {
             "leather_helmet": 55,
             "leather_chestplate": 80,

--- a/feather/old/server/commands/src/arguments.rs
+++ b/feather/old/server/commands/src/arguments.rs
@@ -36,7 +36,7 @@ impl ArgumentKind<CommandCtx> for EntitySelector {
     fn parse<'a>(ctx: &CommandCtx, input: &mut Input<'a>) -> Result<Self, Self::ParseError> {
         let head = input.advance_until(" ");
 
-        // See https://minecraft.gamepedia.com/Commands#Target_selectors
+        // See https://minecraft.wiki/w/Commands#Target_selectors
         let entities = find_selected_entities(ctx, head)?;
 
         Ok(EntitySelector { entities })
@@ -168,7 +168,7 @@ pub enum CoordinatesParseError {
 }
 
 /// Parses a position (<x> <y> <z>, but also with support for relative
-/// positions as per https://minecraft.gamepedia.com/Commands#Tilde_and_caret_notation).
+/// positions as per https://minecraft.wiki/w/Commands#Tilde_and_caret_notation).
 #[derive(Copy, Clone, Debug)]
 pub struct Coordinates {
     pub x: Coordinate,

--- a/feather/old/server/entity/src/fall_damage.rs
+++ b/feather/old/server/entity/src/fall_damage.rs
@@ -46,7 +46,7 @@ pub fn update_blocks_fallen(game: &mut Game, world: &mut World) {
     for entity in landed.into_inner() {
         let blocks_fallen = world.get::<BlocksFallen>(entity).0;
 
-        // https://minecraft.gamepedia.com/Damage#Fall_damage
+        // https://minecraft.wiki/w/Damage#Fall_damage
         let damage = (blocks_fallen - 3.0).max(0.0).round() as u32;
 
         if damage != 0 {

--- a/feather/old/server/player/src/packet_handlers/digging.rs
+++ b/feather/old/server/player/src/packet_handlers/digging.rs
@@ -156,7 +156,7 @@ pub fn advance_dig_progress(game: &mut Game, world: &mut World) {
         world.inner_mut(),
         |(mut digging, inventory, held_item)| {
             // Advance progress depends on tool and the
-            // block kind: https://minecraft.gamepedia.com/Breaking#Speed
+            // block kind: https://minecraft.wiki/w/Breaking#Speed
             // * If the block requires some tool to harvest (i.e. it requires a tool to get the item after it breaks),
             // then if that tool is not held, progress is hindered by a factor of 5. Otherwise, the hindrance
             // is only a factor of 1.5.

--- a/feather/old/server/util/src/block.rs
+++ b/feather/old/server/util/src/block.rs
@@ -118,7 +118,7 @@ fn face_facing_offset(id: BlockId) -> BlockPosition {
 use feather_core::blocks::SimplifiedBlockKind::*;
 
 fn check_block_support_at(id: BlockId, game: &Game, pos: BlockPosition) -> Option<bool> {
-    // TODO leaves are technically a full block, but e.g. torches can't be placed on them https://minecraft.gamepedia.com/Opacity/Placement
+    // TODO leaves are technically a full block, but e.g. torches can't be placed on them https://minecraft.wiki/w/Opacity/Placement
     let block_down = game.block_at(pos + DOWN);
     let block_facing = if id.has_facing_cardinal() {
         game.block_at(pos + id.facing_cardinal().unwrap().opposite().offset())

--- a/libcraft/core/src/gamerules.rs
+++ b/libcraft/core/src/gamerules.rs
@@ -1,4 +1,4 @@
-//! Data sourced from: <https://minecraft.gamepedia.com/Game_rule>
+//! Data sourced from: <https://minecraft.wiki/w/Game_rule>
 
 use serde::{Deserialize, Serialize};
 

--- a/libcraft/items/src/enchantment.rs
+++ b/libcraft/items/src/enchantment.rs
@@ -1,4 +1,4 @@
-//! Data sourced from: <https://minecraft.gamepedia.com/Enchanting#Enchantments>
+//! Data sourced from: <https://minecraft.wiki/w/Enchanting#Enchantments>
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki